### PR TITLE
QT 6.7 does not build on riscv (internal compiler error) 

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -471,7 +471,7 @@ config BR2_TARGET_BATOCERA_IMAGES_DEFINITIONS
 	default "rockchip/rk3328/rock64 rockchip/rk3328/roc-cc"						if BR2_PACKAGE_BATOCERA_TARGET_RK3328
 	default "rockchip/rk3288/tinkerboard rockchip/rk3288/miqi"					if BR2_PACKAGE_BATOCERA_TARGET_RK3288
 	default "rockchip/rk3128/ps5000 rockchip/rk3128/ps7000 rockchip/rk3128/powkiddy_a13"		if BR2_PACKAGE_BATOCERA_TARGET_RK3128
-	default "allwinner/h5/tritium-h5 allwinner/h5/orangepi-pc2 allwinner/h5/orangepi-one-plus"	if BR2_PACKAGE_BATOCERA_TARGET_H5
+	default "allwinner/h5/tritium-h5 allwinner/h5/orangepi-pc2"					if BR2_PACKAGE_BATOCERA_TARGET_H5
 	default "allwinner/h6/orangepi-3-lts allwinner/h6/orangepi-3 allwinner/h6/orangepi-one-plus"	if BR2_PACKAGE_BATOCERA_TARGET_H6
 	default "allwinner/h616/orangepi-zero2 allwinner/h616/orangepi-zero3 allwinner/h616/x96-mate"	if BR2_PACKAGE_BATOCERA_TARGET_H616
 	default "amlogic/s812"										if BR2_PACKAGE_BATOCERA_TARGET_S812
@@ -1147,7 +1147,7 @@ config BR2_PACKAGE_BATOCERA_CONSOLE_SYSTEMS
 	select BR2_PACKAGE_BATOCERA_SEGADC
 
 	# PSX
-	select BR2_PACKAGE_DUCKSTATION			if (!BR2_arm) && BR2_PACKAGE_BATOCERA_GLES3 && !BR2_PACKAGE_BATOCERA_TARGET_RK3326 # newer versions of duckstation are stricter on OpenGL 3.1
+	select BR2_PACKAGE_DUCKSTATION			if (!BR2_riscv) && (!BR2_arm) && BR2_PACKAGE_BATOCERA_GLES3 && !BR2_PACKAGE_BATOCERA_TARGET_RK3326 # newer versions of duckstation stricter on OpenGL 3.1, RISC-V/QT6 fails
 
 	select BR2_PACKAGE_DUCKSTATION_LEGACY		if !BR2_riscv					&& \
 							   !BR2_PACKAGE_BATOCERA_TARGET_BCM2835		&& \


### PR DESCRIPTION
- Both GCC 12 and GCC 13 fail to compile QT 6.7 on riscv
- So remove DuckStation for RISC-V until fix is ready
- Bump BR
- Fix h5 mistake (orangepi-one-plus)