### PR TITLE
Bump WSDD native to 1.10, use system libs per default

### DIFF
--- a/board/batocera/fsoverlay/etc/avahi/services/smb.service
+++ b/board/batocera/fsoverlay/etc/avahi/services/smb.service
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_smb._tcp</type>
+    <port>445</port>
+  </service>
+</service-group>

--- a/package/reglinux/utils/wsdd-native/Config.in
+++ b/package/reglinux/utils/wsdd-native/Config.in
@@ -1,6 +1,8 @@
 config BR2_PACKAGE_WSDD_NATIVE
         bool "wsdd-native"
 	select BR2_HOST_CMAKE_AT_LEAST_3_26
+	select BR2_HOST_PACKAGE_LIBXML2
+	select BR2_PACKAGE_LIBXML2
 
         help
           wsdd implements a Web Service Discovery host daemon. This

--- a/package/reglinux/utils/wsdd-native/wsdd-native.mk
+++ b/package/reglinux/utils/wsdd-native/wsdd-native.mk
@@ -4,12 +4,12 @@
 #
 ################################################################################
 
-WSDD_NATIVE_VERSION = 1.9
+WSDD_NATIVE_VERSION = 1.10
 WSDD_NATIVE_SITE = $(call github,gershnik,wsdd-native,v$(WSDD_NATIVE_VERSION))
 WSDD_NATIVE_LICENSE = BSD
 
-WSDD_NATIVE_DEPENDENCIES += host-cmake
-WSDD_NATIVE_CONF_OPTS += -DWSDDN_PREFER_SYSTEM=OFF -DWSDDN_WITH_SYSTEMD="no" -DCMAKE_BUILD_TYPE=Release
+WSDD_NATIVE_DEPENDENCIES += host-cmake host-libxml2 libxml2
+WSDD_NATIVE_CONF_OPTS += -DWSDDN_PREFER_SYSTEM=ON -DWSDDN_WITH_SYSTEMD="no" -DCMAKE_BUILD_TYPE=Release
 
 define WSDD_NATIVE_INSTALL_TARGET_CMDS
         $(INSTALL) -Dm755 $(@D)/wsddn $(TARGET_DIR)/usr/bin/wsdd


### PR DESCRIPTION
- Bump WSDD native to 1.10
- WSDD native now uses system libs per default
- Add missing avahi service to get ksmbd announced on Linux/macOS