### PR TITLE
Grim depends on jpegturbo extensions, and can fail compiling

### DIFF
--- a/package/batocera/utils/grim/Config.in
+++ b/package/batocera/utils/grim/Config.in
@@ -2,7 +2,7 @@ config BR2_PACKAGE_GRIM
     bool "grim"
     depends on BR2_PACKAGE_WAYLAND
     select BR2_PACKAGE_PIXMAN
-    select BR2_PACKAGE_JPEG
+    select BR2_PACKAGE_LIBPNG
 
     help
         Grab images from a Wayland compositor.

--- a/package/batocera/utils/grim/grim.mk
+++ b/package/batocera/utils/grim/grim.mk
@@ -10,12 +10,9 @@ GRIM_SITE = https://git.sr.ht/~emersion/grim/refs/download/v$(GRIM_VERSION)
 GRIM_LICENSE = MIT
 GRIM_LICENSE_FILES = LICENSE
 
-GRIM_DEPENDENCIES = wayland pixman jpeg
+GRIM_DEPENDENCIES = wayland pixman libpng
 
 GRIM_CONF_OPTS = -Dman-pages=disabled -Dwerror=false
-
-ifeq ($(BR2_riscv),y)
 GRIM_CONF_OPTS += -Djpeg=disabled
-endif
 
 $(eval $(meson-package))


### PR DESCRIPTION
It all dependson build order between libjpeg and jpegturbo, overwriting jpeglib.h in sysroot/usr/include.
Disable JPEG support in Grim to have build reproductibility. Also enforces libpng dependency.
Also enforce grim dependency on libpng, it was not specified.