### PR TITLE
gpicase: removed rule 99-gpicase

### DIFF
--- a/package/reglinux/reglinux-gpicase/reglinux-gpicase.mk
+++ b/package/reglinux/reglinux-gpicase/reglinux-gpicase.mk
@@ -3,21 +3,20 @@
 # gpicase
 #
 ################################################################################
-REGLINUX_GPICASE_VERSION = 0.1
+REGLINUX_GPICASE_VERSION = 0.2
 REGLINUX_GPICASE_SOURCE =
+BR2_EXTERNAL_REGLINUX_GPICAS_PATH=$(BR2_EXTERNAL_BATOCERA_PATH)/package/reglinux/reglinux-gpicase
 
 define REGLINUX_GPICASE_BUILD_CMDS
-	$(HOST_DIR)/bin/linux-dtc $(BR2_EXTERNAL_BATOCERA_PATH)/package/reglinux/reglinux-gpicase/overlays/retroflag-gpicase-overlay.dts -o	$(@D)/retroflag-gpicase.dtbo
-	$(HOST_DIR)/bin/linux-dtc $(BR2_EXTERNAL_BATOCERA_PATH)/package/reglinux/reglinux-gpicase/overlays/retroflag-gpicase2-overlay.dts -o	$(@D)/retroflag-gpicase2.dtbo
-	$(HOST_DIR)/bin/linux-dtc $(BR2_EXTERNAL_BATOCERA_PATH)/package/reglinux/reglinux-gpicase/overlays/retroflag-gpicase2w-overlay.dts -o	$(@D)/retroflag-gpicase2w.dtbo
+	$(HOST_DIR)/bin/linux-dtc $(BR2_EXTERNAL_REGLINUX_GPICAS_PATH)/overlays/retroflag-gpicase-overlay.dts -o	$(@D)/retroflag-gpicase.dtbo
+	$(HOST_DIR)/bin/linux-dtc $(BR2_EXTERNAL_REGLINUX_GPICAS_PATH)/overlays/retroflag-gpicase2-overlay.dts -o	$(@D)/retroflag-gpicase2.dtbo
+	$(HOST_DIR)/bin/linux-dtc $(BR2_EXTERNAL_REGLINUX_GPICAS_PATH)/overlays/retroflag-gpicase2w-overlay.dts -o	$(@D)/retroflag-gpicase2w.dtbo
 endef
 
 define REGLINUX_GPICASE_INSTALL_TARGET_CMDS
 	mkdir -p $(BINARIES_DIR)/rpi-firmware/overlays
 	install -m 0755 $(@D)/*.dtbo	$(BINARIES_DIR)/rpi-firmware/overlays/
-
-	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/reglinux/reglinux-gpicase/scripts/99-gpicase.rules		$(TARGET_DIR)/etc/udev/rules.d/
-	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/reglinux/reglinux-gpicase/scripts/reglinux-gpicase-install	$(TARGET_DIR)/usr/bin/reglinux-gpicase-install
+	install -m 0755 $(BR2_EXTERNAL_REGLINUX_GPICAS_PATH)/scripts/reglinux-gpicase-install	$(TARGET_DIR)/usr/bin/reglinux-gpicase-install
 endef
 
 $(eval $(generic-package))

--- a/package/reglinux/reglinux-gpicase/scripts/99-gpicase.rules
+++ b/package/reglinux/reglinux-gpicase/scripts/99-gpicase.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="usb", ATTR{manufacturer}=="RetroFlag", ATTR{product}=="GPi Case", RUN+="/usr/bin/reglinux-gpicase-install", RUN+="/bin/sh -c '/bin/echo RETROFLAG_GPI > /var/run/powerswitch-by-udevrule'"

--- a/package/reglinux/reglinux-gpicase/scripts/reglinux-gpicase-install
+++ b/package/reglinux/reglinux-gpicase/scripts/reglinux-gpicase-install
@@ -1,49 +1,57 @@
 #!/bin/sh
 
-CONFIGRULES=/etc/udev/rules.d/99-gpicase.rules
 CONFIGFILE=/boot/config.txt
-RPIMODEL="/proc/device-tree/model"
-CONFIGMODIFIED=0
 
-if grep -q "^Raspberry Pi Zero 2" ${RPIMODEL}
-then
-    video="dtoverlay=retroflag-gpicase2w"
-else
-    video="dtoverlay=retroflag-gpicase"
+f_usage() {
+    echo "${0} gpicase" >&2
+    echo "${0} gpicase2" >&2
+    echo "${0} gpicase2w" >&2
+}
+
+do_config(){
+    setup="# ====== GPi Case setup section =====
+    ${video}
+    dtparam=act_led_trigger=none
+    dtparam=act_led_activelow=on
+    # ====== GPi Case setup section end ====="
+
+    echo "${setup}" | (
+    while read LINE
+    do
+        if ! grep -qE "^${LINE}$" "${CONFIGFILE}"
+        then
+            mount -o remount,rw /boot
+            echo "${LINE}" >> "${CONFIGFILE}"
+        fi
+    done
+    )
+    >&2 echo "${ACTION} support installed!"
+    >&2 echo "Please reboot the system so that the changes take effect!"
+}
+
+if [ $# -eq 0 ]; then
+    f_usage
+    exit 1
 fi
 
-setup="# ====== GPi Case setup section =====
-${video}
+ACTION=$1
 
-dtparam=act_led_trigger=none
-dtparam=act_led_activelow=on
-# ====== GPi Case setup section end =====
-# This will preserve always the default GPi settings if enabled, needed if some values were wrong setted by user"
-
-echo "${setup}" | (
-while read LINE
-do
-    if ! grep -qE "^${LINE}$" "${CONFIGFILE}"
-    then
-        test "${CONFIGMODIFIED}" = 0 && mount -o remount,rw /boot
-        echo "${LINE}" >> "${CONFIGFILE}"
-        CONFIGMODIFIED=1
-    fi
-done
-
-# We don't want install to be called on every boot
-if [ -e "${CONFIGRULES}" ];
-then
-    rm -rf "${CONFIGRULES}"
-    batocera-save-overlay
-fi
-
-#Reboot if there was a change in line
-if test "${CONFIGMODIFIED}" = 1
-then
-        echo "Rebooting now..."
-        shutdown -r now
-fi
-)
-
+case "${ACTION}" in
+    "gpicase")
+        video="dtoverlay=retroflag-gpicase"
+        do_config
+    ;;
+    "gpicase2")
+        video="dtoverlay=retroflag-gpicase2"
+        do_config
+    ;;
+    "gpicase2w")
+        video="dtoverlay=retroflag-gpicase2w"
+        do_config
+    ;;
+    *)
+        f_usage
+        >&2 echo "error: invalid command ${ACTION}"
+        exit 1
+esac
 exit 0


### PR DESCRIPTION
It is necessary to find a more efficient way to differentiate each GPICase.

Install:
reglinux-gpicase-install gpicase
reglinux-gpicase-install gpicase2
reglinux-gpicase-install gpicase2w
