### PR TITLE
rpi: updating config.txt settings

### DIFF
--- a/board/batocera/broadcom/bcm2711/boot/config.txt
+++ b/board/batocera/broadcom/bcm2711/boot/config.txt
@@ -9,12 +9,8 @@ arm_64bit=1
 kernel=boot/linux
 initramfs boot/initrd.lz4
 
-# Firmware configurations
-start_file=start4.elf
-fixup_file=fixup4.dat
-
 # sets the initial CEC name of the device
-cec_osd_name=batocera
+cec_osd_name=reglinux
 
 # uncomment will lead to "safe mode" settings being used to try to boot with maximum HDMI compatibility.
 #hdmi_safe=1
@@ -108,7 +104,7 @@ boot_delay=3
 
 # uncomment to avoid the firmware parsing the EDID of any HDMI attached display
 # that way the Linux video mode system (KMS) will then parse the EDID itself and pick an appropriate mode.
-#disable_fw_kms_setup=1
+disable_fw_kms_setup=1
 
 # uncomment for lirc-rpi
 #dtoverlay=lirc-rpi
@@ -139,7 +135,7 @@ dtparam=audio=on
 dtparam=krnbt=on
 
 # Enable DRM VC4 V3D driver
-dtoverlay=vc4-kms-v3d-pi4
+dtoverlay=vc4-kms-v3d,cma-512
 max_framebuffers=1
 
 # Run as fast as firmware/board allows

--- a/board/batocera/broadcom/bcm2712/boot/config.txt
+++ b/board/batocera/broadcom/bcm2712/boot/config.txt
@@ -1,5 +1,150 @@
-arm_boost=1
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# Load the 64-bit kernel
 arm_64bit=1
+
+# Kernel
 kernel=boot/linux
 initramfs boot/initrd.lz4
+
+# sets the initial CEC name of the device
+cec_osd_name=reglinux
+
+# uncomment will lead to "safe mode" settings being used to try to boot with maximum HDMI compatibility.
+#hdmi_safe=1
+
+# uncomment this if your display has a black border of unused pixels visible
+# and your display can output without overscan
+# at 0, it causes flickering on hdmi output
+disable_overscan=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+#hdmi_force_hotplug=1
+
+# uncomment the hdmi_group command which defines the HDMI output group to be either...
+# 1 use CEA (Consumer Electronics Association, the standard typically used by TVs) or
+# 2 use DMT (Display Monitor Timings, the standard typically used by monitors).
+# This setting should be used in conjunction with hdmi_mode.
+#hdmi_group=2
+
+# uncomment to apply an appropriate CEA or DMT mode for your display
+# see the web site below for valid options depending on the hdmi_group setting
+# https://www.raspberrypi.org/documentation/configuration/config-txt/video.md
+#hdmi_mode=4
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment will remove all other modes except the ones specified by hdmi_mode and hdmi_group from the internal list
+# meaning they will not appear in any enumerated lists of modes.
+# this option may help if a display seems to be ignoring the hdmi_mode and hdmi_group settings.
+#hdmi_force_mode=1
+
+# use this option to allow selection of 4k 60Hz refresh rates.
+# note, this will increase power consumption and increase the temperature of the Raspberry Pi.
+# it is not possible to output 4Kp60 on both micro HDMI ports simultaneously.
+#hdmi_enable_4kp60=1
+
+# forces the EDID content type to a specific value.
+# the options are:
+# 0 = EDID_ContentType_NODATA, content type none.
+# 1 = EDID_ContentType_Graphics, content type graphics, ITC must be set to 1
+# 2 = EDID_ContentType_Photo, content type photo
+# 3 = EDID_ContentType_Cinema, content type cinema
+# 4 = EDID_ContentType_Game, content type game
+#edid_content_type=4
+
+# if you plug your tv at the same time as your rpi and that the rpi switches from the hdmi or give a low resolution because tv had no enough time to initialize it
+boot_delay=3
+
+# uncomment to enable composite output via 4 pole TRRS ("headphone") socket.
+# note: slightly slows down the entire system on Pi 4 models.
+#enable_tvout=1
+
+# uncomment for composite mode.
+# 0 Normal NTSC (default)
+# 1 Japanese version of NTSC – no pedestal
+# 2 Normal PAL
+# 3 Brazilian version of PAL – 525/60 rather than 625/50, different subcarrier
+# 16 Progressive scan NTSC
+# 18 Progressive scan PAL
+#sdtv_mode=2
+
+# uncomment to define the wide aspect ratio for composite video output above.
+# 1	4:3 (default)
+# 2	14:9
+# 3	16:9
+#sdtv_aspect=3
+
+# uncomment if you have slow sound issues on composite output
+#audio_pwm_mode=0
+
+# uncomment to pretend that all audio formats are supported by the display
+# allowing passthrough of DTS/AC3 even when this is not reported as supported.
+#hdmi_force_edid_audio=1
+
+# uncomment to pretend that all audio formats are unsupported by the display.
+# this means ALSA will default to the analogue audio (headphone) jack.
+# hdmi_ignore_edid_audio=1
+
+# uncomment to avoid the firmware parsing the EDID of any HDMI attached display
+# that way the Linux video mode system (KMS) will then parse the EDID itself and pick an appropriate mode.
+disable_fw_kms_setup=1
+
+# uncomment for lirc-rpi
+#dtoverlay=lirc-rpi
+
+# uncomment if you don't want the rainbow at startup
+disable_splash=1
+
+# enable UART (required for for retroflag)
+# affect rpi performances
+# enable_uart=1
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Uncomment this to enable infrared communication.
+#dtoverlay=gpio-ir,gpio_pin=17
+#dtoverlay=gpio-ir-tx,gpio_pin=18
+
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+# Enable bluetooth
+dtparam=krnbt=on
+
+# Enable DRM VC4 V3D driver
 dtoverlay=vc4-kms-v3d,cma-512
+max_framebuffers=1
+
+# Run as fast as firmware/board allows
+arm_boost=1
+
+[DPI]
+# Put any DPI required display code here
+# i.e. Official 7" DSI Raspberry Pi Touch Display for 'Full' KMS
+#ignore_lcd=1
+#dtoverlay=vc4-kms-dsi-7inch
+
+[all]

--- a/board/batocera/broadcom/bcm2835/boot/config.txt
+++ b/board/batocera/broadcom/bcm2835/boot/config.txt
@@ -6,12 +6,8 @@
 kernel=boot/linux
 initramfs boot/initrd.lz4
 
-# Firmware configurations
-start_file=start.elf
-fixup_file=fixup.dat
-
 # sets the initial CEC name of the device
-cec_osd_name=batocera
+cec_osd_name=reglinux
 
 # uncomment will lead to "safe mode" settings being used to try to boot with maximum HDMI compatibility.
 #hdmi_safe=1
@@ -105,7 +101,7 @@ boot_delay=3
 
 # uncomment to avoid the firmware parsing the EDID of any HDMI attached display
 # that way the Linux video mode system (KMS) will then parse the EDID itself and pick an appropriate mode.
-#disable_fw_kms_setup=1
+disable_fw_kms_setup=1
 
 # uncomment for lirc-rpi
 #dtoverlay=lirc-rpi

--- a/board/batocera/broadcom/bcm2836/boot/config.txt
+++ b/board/batocera/broadcom/bcm2836/boot/config.txt
@@ -6,12 +6,8 @@
 kernel=boot/linux
 initramfs boot/initrd.lz4
 
-# Firmware configurations
-start_file=start.elf
-fixup_file=fixup.dat
-
 # sets the initial CEC name of the device
-cec_osd_name=batocera
+cec_osd_name=reglinux
 
 # uncomment will lead to "safe mode" settings being used to try to boot with maximum HDMI compatibility.
 #hdmi_safe=1
@@ -105,7 +101,7 @@ boot_delay=3
 
 # uncomment to avoid the firmware parsing the EDID of any HDMI attached display
 # that way the Linux video mode system (KMS) will then parse the EDID itself and pick an appropriate mode.
-#disable_fw_kms_setup=1
+disable_fw_kms_setup=1
 
 # uncomment for lirc-rpi
 #dtoverlay=lirc-rpi

--- a/board/batocera/broadcom/bcm2837/boot/config.txt
+++ b/board/batocera/broadcom/bcm2837/boot/config.txt
@@ -9,12 +9,8 @@ arm_64bit=1
 kernel=boot/linux
 initramfs boot/initrd.lz4
 
-# Firmware configurations
-start_file=start.elf
-fixup_file=fixup.dat
-
 # sets the initial CEC name of the device
-cec_osd_name=batocera
+cec_osd_name=reglinux
 
 # uncomment will lead to "safe mode" settings being used to try to boot with maximum HDMI compatibility.
 #hdmi_safe=1
@@ -108,7 +104,7 @@ boot_delay=3
 
 # uncomment to avoid the firmware parsing the EDID of any HDMI attached display
 # that way the Linux video mode system (KMS) will then parse the EDID itself and pick an appropriate mode.
-#disable_fw_kms_setup=1
+disable_fw_kms_setup=1
 
 # uncomment for lirc-rpi
 #dtoverlay=lirc-rpi


### PR DESCRIPTION
- Remove firmware configurations (videocore)
- Change cec name to reglinux
- Adds CMA: rpi4/5 cma-512
- Enable "disable_fw_kms_setup" (That way the Linux video mode system (KMS) will then parse the EDID itself and pick an appropriate mode.)
