### PR TITLE
Big rework of ScummVM

### DIFF
--- a/package/batocera/emulators/scummvm/Config.in
+++ b/package/batocera/emulators/scummvm/Config.in
@@ -6,7 +6,8 @@ config BR2_PACKAGE_SCUMMVM
     select BR2_PACKAGE_JPEG
     select BR2_PACKAGE_LIBJPEG_BATO
     select BR2_PACKAGE_LIBOGG
-    select BR2_PACKAGE_LIBVORBIS
+    select BR2_PACKAGE_LIBVORBIS	if !BR2_arm && !BR2_mipsel
+    select BR2_PACKAGE_TREMOR		if  BR2_arm || BR2_mipsel
     select BR2_PACKAGE_FLAC
     select BR2_PACKAGE_LIBMAD
     select BR2_PACKAGE_LIBPNG


### PR DESCRIPTION
Make a plugins-based build on non-x86
Enable tremor on ARM 32-bit and MIPS 32-bit
Bump BR to switch to newer tremor repo fixing build (autoconf/autotools error)