### PR TITLE
Fix compiling libretro-same-cdi on 16GB machines (too many jobs)

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-same-cdi/libretro-same-cdi.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-same-cdi/libretro-same-cdi.mk
@@ -8,6 +8,10 @@ LIBRETRO_SAME_CDI_VERSION = 54cf493c2dee4c46666059c452f8aaaa0bd7c8e0
 LIBRETRO_SAME_CDI_SITE = $(call github,libretro,same_cdi,$(LIBRETRO_SAME_CDI_VERSION))
 LIBRETRO_SAME_CDI_LICENSE = GPL
 
+# Limit number of jobs not to eat too much RAM....
+LIBRETRO_SAME_CDI_MAX_JOBS = 6
+LIBRETRO_SAME_CDI_JOBS = $(shell if [ $(PARALLEL_JOBS) -gt $(LIBRETRO_SAME_CDI_MAX_JOBS) ]; then echo $(LIBRETRO_SAME_CDI_MAX_JOBS); else echo $(PARALLEL_JOBS); fi)
+
 define LIBRETRO_SAME_CDI_BUILD_CMDS
 	# First, we need to build genie for host
 	cd $(@D); \
@@ -19,7 +23,7 @@ define LIBRETRO_SAME_CDI_BUILD_CMDS
 	USE_QTDEBUG=0 DEBUG=0 IGNORE_GIT=1 MPARAM=""
 
 	# Then build lr-same-cdi for target
-	$(TARGET_CONFIGURE_OPTS) $(MAKE) CXX="$(TARGET_CXX)" CC="$(TARGET_CC)" GIT_VERSION="" -C $(@D) -f Makefile.libretro
+	$(TARGET_CONFIGURE_OPTS) $(MAKE) -j$(LIBRETRO_SAME_CDI_JOBS) CXX="$(TARGET_CXX)" CC="$(TARGET_CC)" GIT_VERSION="" -C $(@D) -f Makefile.libretro
 endef
 
 define LIBRETRO_SAME_CDI_INSTALL_TARGET_CMDS


### PR DESCRIPTION
Let's do this until we probably remove it, it's x86 only, and just a 2 years+ outdated, unmaintained libretro-mame fork