### PR TITLE
Fix ksmbd not working for Win10/Win11 22H2 

### DIFF
--- a/board/batocera/fsoverlay/etc/ksmbd/ksmbd.conf
+++ b/board/batocera/fsoverlay/etc/ksmbd/ksmbd.conf
@@ -2,11 +2,13 @@
 
 [REGLINUX]
 	; share parameters
+	security = user
 	browseable = yes
 	comment = REGLINUX share data
 	create mask = 0777
 	directory mask = 0775
 	force user = root
+        guest account = root
 	guest ok = yes
 	guest only = yes
 	netbios name = REGLINUX


### PR DESCRIPTION
login: root, blank password
Still works 100% anonymously on Linux clients.