### PR TITLE
Ignore EDID screen resolution above 1080p in H3 boards

### DIFF
--- a/board/batocera/allwinner/h3/linux_patches/0001-limit-resolution-to-max-1080p.patch
+++ b/board/batocera/allwinner/h3/linux_patches/0001-limit-resolution-to-max-1080p.patch
@@ -1,0 +1,11 @@
+--- a/drivers/gpu/drm/drm_edid.c	2024-04-13 12:07:41.000000000 +0100
++++ a/drivers/gpu/drm/drm_edid.c	2024-06-26 00:21:30.180353959 +0100
+@@ -3025,7 +3025,7 @@
+ {
+ 	BUILD_BUG_ON(offsetof(typeof(*descriptor), pixel_clock) != 0);
+ 
+-	return descriptor->pixel_clock != 0;
++	return (descriptor->pixel_clock > 0 && descriptor->pixel_clock < 15000);
+ }
+ 
+ typedef void detailed_cb(const struct detailed_timing *timing, void *closure);

--- a/configs/batocera-h3.board
+++ b/configs/batocera-h3.board
@@ -21,7 +21,7 @@ BR2_PACKAGE_UBOOT_MULTIBOARD=y
 # Kernel
 BR2_LINUX_KERNEL=y
 BR2_LINUX_KERNEL_LATEST_VERSION=y
-BR2_LINUX_KERNEL_PATCH="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/linux_patches"
+BR2_LINUX_KERNEL_PATCH="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/linux_patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/h3/linux_patches"
 BR2_LINUX_KERNEL_USE_CUSTOM_CONFIG=y
 BR2_LINUX_KERNEL_CUSTOM_CONFIG_FILE="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/linux-sunxi32-current.config"
 BR2_LINUX_KERNEL_CONFIG_FRAGMENT_FILES="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/linux-defconfig-fragment.config"

--- a/package/batocera/boot/uboot-multiboard/common-h3/0002-limit-resolution-to-max-1080p-uboot.patch
+++ b/package/batocera/boot/uboot-multiboard/common-h3/0002-limit-resolution-to-max-1080p-uboot.patch
@@ -1,0 +1,11 @@
+--- a/common/edid.c	2023-01-09 16:07:33.000000000 +0000
++++ b/common/edid.c	2024-06-25 22:38:26.403079356 +0100
+@@ -180,7 +180,7 @@
+ 	int i;
+ 
+ 	for (i = 0; i < count && !found; i++, t++)
+-		if (EDID_DETAILED_TIMING_PIXEL_CLOCK(*t) != 0) {
++		if (EDID_DETAILED_TIMING_PIXEL_CLOCK(*t) > 0 && EDID_DETAILED_TIMING_PIXEL_CLOCK(*t) < 150000000) {
+ 			decode_timing((u8 *)t, timing);
+ 			if (mode_valid)
+ 				found = mode_valid(mode_valid_priv,


### PR DESCRIPTION
With this patches for H3 boards, both u-boot and kernel will discard EDID screen resolution above 1080p.