### PR TITLE
Add support for Ares (requires 64bit arch + desktop GL / X). Not built by default.

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -549,6 +549,7 @@ menu "REG.linux"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/reglinux/boot/mininit/Config.in"
 
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/reglinux/emulators/86Box/Config.in"
+  source "$BR2_EXTERNAL_BATOCERA_PATH/package/reglinux/emulators/ares/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/reglinux/emulators/box86/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/reglinux/emulators/box64/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/reglinux/emulators/cemu/Config.in"

--- a/package/reglinux/emulators/ares/001-some-makefile-fixes.patch
+++ b/package/reglinux/emulators/ares/001-some-makefile-fixes.patch
@@ -1,0 +1,46 @@
+--- a/hiro/GNUmakefile	2024-08-28 13:21:13.740204423 +0200
++++ b/hiro/GNUmakefile	2024-08-28 13:22:05.489426921 +0200
+@@ -51,26 +51,26 @@
+ 
+   ifeq ($(hiro),gtk2)
+     hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(pkg_config) --cflags gtk+-2.0) -Wno-deprecated-declarations
+-    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs gtk+-2.0)
++    hiro.options = -lX11 $(shell $(pkg_config) --libs gtk+-2.0)
+   else ifeq ($(hiro),gtk2-se)
+     flags       += -DHiro_SourceEdit
+     hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(pkg_config) --cflags gtk+-2.0 gtksourceview-2.0) -Wno-deprecated-declarations
+-    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs gtk+-2.0 gtksourceview-2.0)
++    hiro.options = -lX11 $(shell $(pkg_config) --libs gtk+-2.0 gtksourceview-2.0)
+   else ifeq ($(hiro),gtk3)
+     hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(pkg_config) --cflags gtk+-3.0) -Wno-deprecated-declarations
+-    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs gtk+-3.0)
++    hiro.options = -lX11 $(shell $(pkg_config) --libs gtk+-3.0)
+   else ifeq ($(hiro),gtk3-se)
+     flags       += -DHiro_SourceEdit
+     hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(pkg_config) --cflags gtk+-3.0 gtksourceview-3.0) -Wno-deprecated-declarations
+-    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs gtk+-3.0 gtksourceview-3.0)
++    hiro.options = -lX11 $(shell $(pkg_config) --libs gtk+-3.0 gtksourceview-3.0)
+   else ifeq ($(hiro),qt4)
+     moc = /usr/local/lib/qt4/bin/moc
+     hiro.flags   = $(flags.cpp) -DHIRO_QT=4 $(shell $(pkg_config) --cflags QtCore QtGui)
+-    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs QtCore QtGui)
++    hiro.options = -lX11 $(shell $(pkg_config) --libs QtCore QtGui)
+   else ifeq ($(hiro),qt5)
+     moc = $(shell $(pkg_config) --variable=host_bins Qt5Core)/moc
+     hiro.flags   = $(flags.cpp) -DHIRO_QT=5 -fPIC $(shell $(pkg_config) --cflags Qt5Core Qt5Gui Qt5Widgets)
+-    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs Qt5Core Qt5Gui Qt5Widgets)
++    hiro.options = -lX11 $(shell $(pkg_config) --libs Qt5Core Qt5Gui Qt5Widgets)
+   else
+     $(error unrecognized hiro backend $(hiro))
+   endif
+--- a/nall/GNUmakefile	2024-08-27 18:37:58.000000000 +0200
++++ b/nall/GNUmakefile	2024-08-28 13:26:46.011035481 +0200
+@@ -318,7 +318,7 @@
+ 
+ # linux settings
+ ifeq ($(platform),linux)
+-  options += -ldl
++  options += -ldl -lm -lstdc++
+ endif
+ 
+ # bsd settings

--- a/package/reglinux/emulators/ares/Config.in
+++ b/package/reglinux/emulators/ares/Config.in
@@ -1,0 +1,12 @@
+config BR2_PACKAGE_ARES
+    bool "ares"
+    select BR2_PACKAGE_SDL2
+    select BR2_PACKAGE_ZLIB
+    depends on BR2_PACKAGE_HAS_LIBGL
+  
+    help
+      ares is a cross-platform, open source, multi-system emulator, focusing on accuracy and preservation.
+
+      https://ares-emu.net/
+
+

--- a/package/reglinux/emulators/ares/ares.mk
+++ b/package/reglinux/emulators/ares/ares.mk
@@ -1,0 +1,25 @@
+################################################################################
+#
+# ares
+#
+################################################################################
+# Version.: Release on Aug 27, 2024
+ARES_VERSION = v140
+ARES_SITE = $(call github,ares-emulator,ares,$(ARES_VERSION))
+ARES_LICENSE = GPLv3
+ARES_DEPENDENCIES = sdl2 libgl zlib
+
+ARES_FLAGS = -I$(STAGING_DIR)/usr/include/glib-2.0 -I$(STAGING_DIR)/usr/lib/glib-2.0/include -I$(STAGING_DIR)/usr/include/pango-1.0 -I$(STAGING_DIR)/usr/include/cairo -I$(STAGING_DIR)/usr/include/harfbuzz -I$(STAGING_DIR)/usr/include/gtk-3.0 -I$(STAGING_DIR)/usr/include/gdk-pixbuf-2.0  -I$(STAGING_DIR)/usr/include/atk-1.0
+
+define ARES_BUILD_CMDS
+	SYSROOT="$(STAGING_DIR)" \
+        PKG_CONFIG="$(HOST_DIR)/usr/bin/pkg-config --define-prefix" \
+        PKG_CONFIG_PATH="$(STAGING_DIR)/usr/lib/pkgconfig" \
+        CFLAGS="--sysroot=$(STAGING_DIR)" \
+        CPPFLAGS="--sysroot=$(STAGING_DIR)" \
+        CXXFLAGS="--sysroot=$(STAGING_DIR)" \
+        LDFLAGS="--sysroot=$(STAGING_DIR)" \
+	$(MAKE) compiler="$(TARGET_CC)" flags.cpp="$(ARES_FLAGS)" verbose local=false platform=linux hiro=gtk3 librashader=false vulkan=false -C $(@D) -f ./GNUmakefile
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
x86_64, rk3588, jh7110 and build fine.
NOT included or built by default, can be fine tweaked later ;)