### PR TITLE
Multiple scripts (tiny) optimizations

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -29,9 +29,9 @@ printf "Starting share: "
 
 SHARECONFFILE="/boot/batocera-boot.conf"
 INTERNALDEVICE=$(batocera-part "share_internal")
-INTERNALDEVICETYPE=$(blkid "${INTERNALDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)\".*'+'\1'+)
+INTERNALDEVICETYPE=$(blkid -o value -s TYPE "${INTERNALDEVICE}")
 
-SHAREDEVICE=$(cat "${SHARECONFFILE}" | grep -E '^[ ]*sharedevice=' | head -n1 | cut -d'=' -f2)
+SHAREDEVICE=$(cat "${SHARECONFFILE}" | grep -m 1 -E '^[ ]*sharedevice=' | cut -d'=' -f2)
 [ "$?" -ne "0" -o "$SHAREDEVICE" = "" ] && SHAREDEVICE=INTERNAL
 
 getMaxTryConfig() {
@@ -290,12 +290,12 @@ fi
 
 case "${MODE}" in
     "DEV")
-        LDEVICE=$(blkid | grep " UUID=\"${UUID}\"" | head -1)
+        LDEVICE=$(blkid | grep -m 1 " UUID=\"${UUID}\"")
         while [ -z "${LDEVICE}" -a "${NTRY}" -lt "${MAXTRY}" ] # wait the device that can take some seconds after udev started
         do
             NTRY=$((NTRY+1))
             sleep 1
-            LDEVICE=$(blkid | grep " UUID=\"${UUID}\"" | head -1)
+            LDEVICE=$(blkid | grep -m 1 " UUID=\"${UUID}\"")
         done
         DEVICE=$(echo "${LDEVICE}" | sed -e s+'^\([^:]*\):.*$'+'\1'+)
         TDEVICE=$(echo "${LDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)".*$'+'\1'+)
@@ -308,7 +308,7 @@ case "${MODE}" in
         do
             NTRY=$((NTRY+1))
             sleep 1
-            LDEVICE=$(blkid | grep -vE "^${PARTPREFIX}" | head -1)
+            LDEVICE=$(blkid | grep -m 1 -vE "^${PARTPREFIX}")
         done
         DEVICE=$(echo "${LDEVICE}" | sed -e s+'^\([^:]*\):.*$'+'\1'+)
         TDEVICE=$(echo "${LDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)".*$'+'\1'+)

--- a/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.drm
+++ b/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.drm
@@ -75,7 +75,7 @@ f_listModes() {
 f_currentResolution() {
     DRMCONN=$(cat /var/run/drmConn)
     DRMMODE=$(cat /var/run/drmMode)
-    f_listModes "all" | grep -E "^${DRMCONN}\.${DRMMODE}\." | head -1 | sed -e s+"^[^:]*:[^ ]* \([0-9]*x[0-9]*\) .*$"+"\1"+
+    f_listModes "all" | grep -m 1 -E "^${DRMCONN}\.${DRMMODE}\." | sed -e s+"^[^:]*:[^ ]* \([0-9]*x[0-9]*\) .*$"+"\1"+
 }
 
 f_minTomaxResolution() {

--- a/package/batocera/core/batocera-scripts/scripts/batocera-brightness
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-brightness
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-D=$(find /sys/class/backlight/* 2>/dev/null | grep backlight | head -n1)
+D=$(find /sys/class/backlight/* 2>/dev/null | grep -m 1 backlight)
 CYCLESTEP=20 # % additional brightbess at each step
 
 if test ! -e "${D}"/brightness

--- a/package/batocera/core/batocera-scripts/scripts/batocera-info
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-info
@@ -70,7 +70,7 @@ fi
 V_BOARD=$(cat /boot/boot/batocera.board)
 V_CPUNB=$(LANG=C lscpu | grep 'Core(s) per socket' | awk '{print $4}' | head -n 1)
 V_CPUMAXNB=$(LANG=C lscpu | grep '^CPU(s):' | awk '{print $2}')
-V_CPUMODEL1=$(grep -E $'^model name\t:' /proc/cpuinfo | head -1 | sed -e s+'^model name\t: '++)
+V_CPUMODEL1=$(grep -m 1 -E $'^model name\t:' /proc/cpuinfo | sed -e s+'^model name\t: '++)
 V_SYSTEM=$(uname -rs)
 # min freq : minimum freq among the max cpus ; consider only online cpus
 V_CPUMINFREQ=$(for CPU in /sys/devices/system/cpu/cpu*; do getCpu "${CPU}"; done | sort -n  | head -1)
@@ -98,7 +98,7 @@ if [ "$V_BOARD" != "$V_ARCH" ]; then
 fi
 
 if echo "${V_BOARD}" | grep -qE "^rpi[0-9]$"; then
-    REVISION=$(grep -E $'^Revision\t:' /proc/cpuinfo | head -1 | sed -e s+'^Revision\t: '++)
+    REVISION=$(grep -m 1 -E $'^Revision\t:' /proc/cpuinfo  | sed -e s+'^Revision\t: '++)
     test -n "${REVISION}" && echo "Revision: ${REVISION}"
 fi
 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-install
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-install
@@ -133,7 +133,7 @@ do_install() {
 	mkdir -p "${IMGFOLDER}/${INSARCH}" || return 1
 
 	# url
-	RELATIVPATH=$(wget -qO - "${updateurl}/installs.txt" | grep -E "^${INSARCH}/" | head -1)
+	RELATIVPATH=$(wget -qO - "${updateurl}/installs.txt" | grep -m 1 -E "^${INSARCH}/")
 	FILEBASENAME=$(basename "${RELATIVPATH}")
 	INSIMG="${IMGFOLDER}/${INSARCH}/${FILEBASENAME}"
 	test -z "${RELATIVPATH}" && return 1

--- a/package/batocera/core/batocera-scripts/scripts/batocera-part
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-part
@@ -39,10 +39,6 @@ determine_default_share_part_num() {
   fi
 }
 
-determine_share_part() {
-    determine_X_part "/userdata"
-}
-
 determine_part_prefix() {
   # /dev/mmcblk0p3 => /dev/mmcblk0
   # /dev/sda1      => /dev/sda
@@ -86,21 +82,18 @@ case "${PARTNAME}" in
   ;;
 
   "share")
-    determine_share_part
+    determine_X_part "/userdata"
   ;;
 
   "prefix")
     determine_part_prefix "$2"
   ;;
 
-  "previous")
-    determine_previous_part "$2"
-  ;;
-
   *)
-    echo "${0} <boot|share_internal|prefix x|previous x>" >&2
+    echo "${0} <boot|share_internal|share_internal_num|prefix x|previous x>" >&2
     echo "  boot: the REG Linux boot partition" >&2
     echo "  share_internal: the REG Linux share internal partition " >&2
+    echo "  share_internal_num: the number of share_internal partition" >&2
     echo "  share: the REG Linux share partition " >&2
     echo "  prefix x: the disk of the partition x (without the partition number)" >&2
     echo "  previous x: the partition before x on the same disk" >&2

--- a/package/batocera/core/batocera-scripts/scripts/batocera-sync
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-sync
@@ -14,7 +14,7 @@ rs_current() {
 # while it could be mounting over the batocera subdirectory or something else
 # we try to use an existing mount point because ntfs-3g doesn't support multiple mount points
 rs_mounted_point() {
-    grep -E "^${1} /media/usb" /proc/mounts | cut -d' ' -f 2 | grep -E '^/media/usb[0-9]$' | head -1
+    grep -E "^${1} /media/usb" /proc/mounts | cut -d' ' -f 2 | grep -m 1 -E '^/media/usb[0-9]$'
 }
 
 rs_list() {

--- a/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
+++ b/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
@@ -118,7 +118,7 @@ do
 	user_output2="$(batocera-settings-get global.videooutput2)"
 	if test "${user_output2}" != "none"
 	then
-	    settings_output2=$(batocera-resolution listOutputs | grep -vE "^${settings_output}$" | head -1)
+	    settings_output2=$(batocera-resolution listOutputs | grep -m 1 -vE "^${settings_output}$")
 	fi
     fi
 

--- a/package/reglinux/reglinux-screen/scripts/resolution/resolution.drm
+++ b/package/reglinux/reglinux-screen/scripts/resolution/resolution.drm
@@ -41,7 +41,7 @@ f_listModes() {
 f_currentResolution() {
     DRMCONN=$(cat /var/run/drmConn)
     DRMMODE=$(cat /var/run/drmMode)
-    f_listModes "all" | grep -E "^${DRMCONN}\.${DRMMODE}\." | head -1 | sed -e s+"^[^:]*:[^ ]* \([0-9]*x[0-9]*\) .*$"+"\1"+
+    f_listModes "all" | grep -m 1 -E "^${DRMCONN}\.${DRMMODE}\." | sed -e s+"^[^:]*:[^ ]* \([0-9]*x[0-9]*\) .*$"+"\1"+
 }
 
 f_minTomaxResolution() {


### PR DESCRIPTION
Avoid using "grep ... | head -1" pipes and use "grep -m1 ..." instead.

Also add missing help text in batocera-part