### PR TITLE
Ignore hidden files in batocera-services folders

### DIFF
--- a/board/batocera/fsoverlay/etc/profile.d/20-alias.sh
+++ b/board/batocera/fsoverlay/etc/profile.d/20-alias.sh
@@ -1,4 +1,4 @@
 # ---- ALIAS VALUES ----
 alias mc='mc -xc'
-alias batocera-check-updates='batocera-es-swissknife --update'
+alias reglinux-check-updates='batocera-es-swissknife --update'
 alias which='command -v'

--- a/board/batocera/fsoverlay/etc/profile.d/30-welcome.sh
+++ b/board/batocera/fsoverlay/etc/profile.d/30-welcome.sh
@@ -9,8 +9,8 @@ echo '
            Retro Emulation Gaming Linux
 '
 echo
-echo "-- type 'batocera-check-updates' to check for stable branch --"
-echo "-- add 'butterfly' switch to check for latest arch developments  --"
+echo "-- type 'reglinux-check-updates' to check for stable branch --"
+echo "-- add 'beta' switch to check for latest arch developments  --"
 echo
 batocera-info 2>/dev/null
 echo "OS version: $(batocera-version)"

--- a/package/batocera/core/batocera-scripts/scripts/batocera-services
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-services
@@ -39,7 +39,8 @@ do_list() {
             ;;
     esac
 
-    find -L $service_folders -type f 2>/dev/null | sort -u |
+    # Ignore hidden files (.*)
+    find -L $service_folders -type f -not -iname ".*" 2>/dev/null | sort -u |
 	while read SERVICE
 	do
 	    SNAME=$(basename "${SERVICE}")


### PR DESCRIPTION
Stop complaining about the '.keep' file that exists in service folder.