### PR TITLE
Show disk names in "Format Device" menu

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-format
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-format
@@ -33,20 +33,21 @@ disks_to_keep() {
 
 do_listDisks() {
     echo "INTERNAL INTERNAL"
-    lsblk -n -P -o TYPE,NAME,SIZE,MODEL |
-	grep -E '^TYPE=\"disk\" ' |
-	sed -e s+' [ ]*"$'+'"'+ | # remove trailing spaces
-	sed -e s+'^TYPE="[^"]*" NAME=\"\([^"]*\)\" SIZE=\"\([^"]*\)\" MODEL=\"\([^"]*\)\"$'+'\1 \3 (\2)'+ |
-	while read XDRIVE XTEXT
-	do
-	    for XKEEP in $(disks_to_keep)
-	    do
-		if test "${XKEEP}" != "${XDRIVE}"
-		then
-		    echo "${XDRIVE} ${XTEXT}"
-		fi
-	    done
-	done
+    lsblk -A -n -P -o TYPE,NAME,SIZE,MODEL | grep -E '^TYPE="disk" ' | grep -ve 'mmcblk.boot' |    # Ignore /dev/mmkblk?boot? special devices
+        sed -e s+'.*NAME=\"\([^"]*\)\" SIZE=\"\([^"]*\)\" MODEL=\"\([^"]*\)\".*'+'\1 (\2) \3'+ |
+        while read XDRIVE XSIZE XMODEL
+        do
+            for XKEEP in $(disks_to_keep)
+            do
+                if test "$XKEEP" != "$XDRIVE"; then
+                    if test -n "$XMODEL"; then
+                        echo "$XDRIVE $XMODEL $XSIZE"
+                    else
+                        echo "$XDRIVE $XDRIVE $XSIZE"
+                    fi
+                fi
+            done
+        done
 }
 
 do_listFstypes() {


### PR DESCRIPTION
The list of devices showed only the size, without any name. Also ignore special /dev/mmcblk?boot? "disks"