### PR TITLE
jazz2: needs to be Jazz2-native as configgen-defaults.yml

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -5551,7 +5551,7 @@ ps4:
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:ps4
 
-jazz2:
+jazz2-native:
   name: Jazz Jackrabbit 2
   manufacturer: Ports
   release: 1998
@@ -5560,8 +5560,8 @@ jazz2:
   platform: pc
   group: ports
   emulators:
-    jazz2-native:
-      jazz2-native: { requireAnyOf: [BR2_PACKAGE_JAZZ2_NATIVE] }
+  jazz2-native:
+  jazz2-native: { requireAnyOf: [BR2_PACKAGE_JAZZ2_NATIVE] }
   comment_en: |
     Jazz2 Native requires the original Jazz Jackrabbit 2 game files.
     Copy all game files into this directory.


### PR DESCRIPTION
Or build clash with:
Traceback (most recent call last):
  File "/build/package/batocera/emulationstation/batocera-es-system/batocera-report-system.py", line 218, in <module>
    EsSystemConf.generate(args.yml, args.explanationsYaml, args.configsDir, args.defaultsDir)
  File "/build/package/batocera/emulationstation/batocera-es-system/batocera-report-system.py", line 80, in generate
    emulators = EsSystemConf.listEmulators(arch, system, rules[system], explanations, config, defaultEmulator, defaultCore)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/build/package/batocera/emulationstation/batocera-es-system/batocera-report-system.py", line 182, in listEmulators
    raise Exception("default core ({}/{}) not enabled for {}/{}" . format(defaultEmulator, defaultCore, arch, system))
Exception: default core (None/None) not enabled for rk3288/jazz2