### PR TITLE
As per @glebm tips, devilutionX 1.5+ uses modern ZeroTier not relying…

### DIFF
--- a/package/reglinux/ports/devilutionx/devilutionx.mk
+++ b/package/reglinux/ports/devilutionx/devilutionx.mk
@@ -20,17 +20,6 @@ DEVILUTIONX_CONF_OPTS += -DBUILD_TESTING=OFF -DPREFILL_PLAYER_NAME=ON \
 # They should all be present in the source package.
 DEVILUTIONX_CONF_OPTS += -DFETCHCONTENT_FULLY_DISCONNECTED=ON
 
-# ZeroTier on aarch64 uses ARMv8 Cryptography Extensions.
-# These extension are optional and only certain Armv8-A CPUs support them.
-# Disables ZeroTier if the CPU compilation flags do not specify the "+crypto" extension.
-ifeq ($(BR2_aarch64)$(BR2_ARM_CPU_ARMV8A),yy)
-    ifneq ($(findstring +crypto,$(BR2_TARGET_OPTIMIZATION)),+crypto)
-        DEVILUTIONX_CONF_OPTS += -DDISABLE_ZERO_TIER=ON
-    endif
-else ifeq ($(BR2_arm),y)
-    DEVILUTIONX_CONF_OPTS += -DDISABLE_ZERO_TIER=ON
-endif
-
 define DEVILUTIONX_INSTALL_TARGET_EVMAPY
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
 	cp $(BR2_EXTERNAL_REGLINUX_PATH)/package/reglinux/ports/devilutionx/devilutionx.keys $(TARGET_DIR)/usr/share/evmapy


### PR DESCRIPTION
… on ARMv8 crypto

So let's enable ZeroTier everywhere.