### PR TITLE
Rework/cleanup default configs

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-a3gen2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-a3gen2.yml
@@ -22,7 +22,3 @@ fmtowns:
 ps2:
   emulator: libretro
   core:     play
-flash:
-  emulator: lightspark
-  core:     lightspark
-

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2711.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2711.yml
@@ -11,9 +11,6 @@ pcenginecd:
 nds:
   emulator: drastic
   core:     drastic
-flash:
-  emulator: lightspark
-  core:     lightspark
 fmtowns:
   emulator: libretro
   core:     mame
@@ -22,9 +19,6 @@ model3:
   core:     supermodel-legacy
   options:
     videomode: max-720x576
-scummvm:
-  emulator: scummvm
-  core:     scummvm
 quake3:
   emulator: ioquake3
   core:     ioquake3

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2712.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2712.yml
@@ -11,31 +11,16 @@ pcenginecd:
 nds:
   emulator: drastic
   core:     drastic
-flash:
-  emulator: lightspark
-  core:     lightspark
-fmtowns:
-  emulator: libretro
-  core:     mame
 model3:
   emulator: supermodel
   core:     supermodel-legacy
   options:
     videomode: max-1920x1080
-scummvm:
-  emulator: scummvm
-  core:     scummvm
 quake3:
   emulator: ioquake3
   core:     ioquake3
   options:
     videomode: max-1920x1080
-gamecube:
-  emulator: dolphin
-  core:     dolphin
-wii:
-  emulator: dolphin
-  core:     dolphin
 jaguar:
   emulator: bigpemu
   core:     bigpemu

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2837.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2837.yml
@@ -21,7 +21,4 @@ dreamcast:
 naomi:
   emulator: libretro
   core:     flycastvl
-flash:
-  emulator: lightspark
-  core:     lightspark
 

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-h5.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-h5.yml
@@ -50,6 +50,3 @@ systemsp:
 fmtowns:
   emulator: libretro
   core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-h6.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-h6.yml
@@ -11,9 +11,6 @@ nds:
 fmtowns:
   emulator: libretro
   core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark
 atomiswave:
   emulator: flycast
   core:     flycast

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-jh7110.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-jh7110.yml
@@ -4,9 +4,6 @@ nds:
 fmtowns:
   emulator: libretro
   core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark
 model3:
   emulator: supermodel
   core:     supermodel-legacy

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-k1.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-k1.yml
@@ -4,9 +4,6 @@ nds:
 fmtowns:
   emulator: libretro
   core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark
 model3:
   emulator: supermodel
   core:     supermodel-legacy

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-mt8395.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-mt8395.yml
@@ -4,24 +4,12 @@ pcengine:
 pcenginecd:
   emulator: libretro
   core:     pce
-gamecube:
-  emulator: dolphin
-  core:     dolphin
 nds:
   emulator: libretro
   core:     melonds
-wii:
-  emulator: dolphin
-  core:     dolphin
-fmtowns:
-  emulator: libretro
-  core:     mame
 ps2:
   emulator: libretro
   core:     play
-flash:
-  emulator: lightspark
-  core:     lightspark
 model3:
   emulator: supermodel
   core:     supermodel-legacy

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odin.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odin.yml
@@ -1,6 +1,3 @@
-flash:
-  emulator: lightspark
-  core:     lightspark
 fmtowns:
   emulator: libretro
   core:     mame

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3328.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3328.yml
@@ -8,6 +8,3 @@ default:
 fmtowns:
   emulator: libretro
   core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3399.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3399.yml
@@ -7,7 +7,4 @@ fmtowns:
 nds:
   emulator: libretro
   core:     melonds
-flash:
-  emulator: lightspark
-  core:     lightspark
 

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3568.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3568.yml
@@ -1,22 +1,12 @@
 3ds:
   emulator: libretro
   core:     panda3ds
-gamecube:
-  emulator: libretro
-  core:     dolphin
 nds:
   emulator: libretro
   core:     melonds
-wii:
-  emulator: libretro
-  core:     dolphin
 fmtowns:
   emulator: libretro
   core:     mame
 ps2:
   emulator: libretro
   core:     play
-flash:
-  emulator: lightspark
-  core:     lightspark
-

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3588.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3588.yml
@@ -4,24 +4,12 @@ pcengine:
 pcenginecd:
   emulator: libretro
   core:     pce
-gamecube:
-  emulator: dolphin
-  core:     dolphin
 nds:
   emulator: libretro
   core:     melonds
-wii:
-  emulator: dolphin
-  core:     dolphin
-fmtowns:
-  emulator: libretro
-  core:     mame
 ps2:
   emulator: libretro
   core:     play
-flash:
-  emulator: lightspark
-  core:     lightspark
 model3:
   emulator: supermodel
   core:     supermodel-legacy

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
@@ -33,7 +33,3 @@ cplus4:
 fmtowns:
   emulator: libretro
   core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark
-

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen2.yml
@@ -14,7 +14,4 @@ nds:
 fmtowns:
   emulator: libretro
   core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark
 

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen3.yml
@@ -14,7 +14,3 @@ nds:
 fmtowns:
   emulator: libretro
   core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark
-

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s922x.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s922x.yml
@@ -10,24 +10,15 @@ pcenginecd:
 model3:
   emulator: supermodel
   core:     supermodel-legacy
-gamecube:
-  emulator: libretro
-  core:     dolphin
 nds:
   emulator: libretro
   core:     melonds
-wii:
-  emulator: libretro
-  core:     dolphin
 fmtowns:
   emulator: libretro
   core:     mame
 ps2:
   emulator: libretro
   core:     play
-flash:
-  emulator: lightspark
-  core:     lightspark
 jaguar:
   emulator: bigpemu
   core:     bigpemu

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s9gen4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s9gen4.yml
@@ -20,9 +20,6 @@ dreamcast:
 naomi:
   emulator: libretro
   core:     flycast
-flash:
-  emulator: lightspark
-  core:     lightspark
 gamecube:
   emulator: libretro
   core:     dolphin

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-saphira.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-saphira.yml
@@ -4,20 +4,8 @@ pcengine:
 pcenginecd:
   emulator: libretro
   core:     pce
-gamecube:
-  emulator: dolphin
-  core:     dolphin
-wii:
-  emulator: dolphin
-  core:     dolphin
 advision:
   emulator: mame
-  core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark
-fmtowns:
-  emulator: libretro
   core:     mame
 lcdgames:
   emulator: mame

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-sm8250.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-sm8250.yml
@@ -4,20 +4,8 @@ pcengine:
 pcenginecd:
   emulator: libretro
   core:     pce
-gamecube:
-  emulator: dolphin
-  core:     dolphin
-wii:
-  emulator: dolphin
-  core:     dolphin
 advision:
   emulator: mame
-  core:     mame
-flash:
-  emulator: lightspark
-  core:     lightspark
-fmtowns:
-  emulator: libretro
   core:     mame
 lcdgames:
   emulator: mame


### PR DESCRIPTION
Rework default configs following somes changes, especially :
- Ruffle being built on all 64-bit architectures by default (prever over lightspartk)
- Tsugaru (fmtowns) being built on Cortex-A76 and better AArch64

Removed duplicate entries, like gamecube/wii is already dolphin/dolphin by default no need to bloat each board config
More cleanup can probably be done at a later point.