### PR TITLE
Environment variables (wayland/drm)

### DIFF
--- a/package/system/reglinux-emulationstation/S31emulationstation
+++ b/package/system/reglinux-emulationstation/S31emulationstation
@@ -21,8 +21,7 @@ start)
 
 	enabled="$($SYSTEM_SETTINGS_GET system.es.atstartup)"
 	if [ "$enabled" != "0" ]; then
-		environment="$($SYSTEM_SETTINGS_GET system.es.environment)"
-		if [ "$environment" = "wayland" ]; then
+		if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 			WLR_LIBINPUT_NO_DEVICES=1 /usr/bin/sway &
 		else
 			%REGLINUX_EMULATIONSTATION_CMD% %REGLINUX_EMULATIONSTATION_POSTFIX%

--- a/package/system/reglinux-system/xdg.sh
+++ b/package/system/reglinux-system/xdg.sh
@@ -1,3 +1,14 @@
 #!/bin/sh
 
 export XDG_RUNTIME_DIR=/var/run
+
+environment="$(/usr/bin/system-settings-get-master system.es.environment)"
+
+if [ "$environment" = "wayland" ]; then
+	export XDG_SESSION_TYPE=wayland
+	export SDL_VIDEO_DRIVER=wayland
+	export QT_QPA_PLATFORM=wayland
+else
+	export XDG_SESSION_TYPE=drm
+	export QT_QPA_PLATFORM=xcb
+fi


### PR DESCRIPTION
Set environment variables at startup according to the graphical environment.
