### PR TITLE
alsa-ucm: bump to v1.2.14

### DIFF
--- a/package/audio/alsa-ucm-conf/alsa-ucm-conf.mk
+++ b/package/audio/alsa-ucm-conf/alsa-ucm-conf.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-ALSA_UCM_CONF_VERSION = v1.2.13
+ALSA_UCM_CONF_VERSION = v1.2.14
 ALSA_UCM_CONF_SITE = $(call github,alsa-project,alsa-ucm-conf,$(ALSA_UCM_CONF_VERSION))
 ALSA_UCM_CONF_LICENSE = BSD-3-Clause
 ALSA_UCM_CONF_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Core
 - github: use ucm-validator2, use actions/checkout@v4
Configuration
 - USB-Audio: Add support of HyperX SoloCast (USB ID 03f0:0b8b)
 - ucm2: Qualcomm: add Asus Zenbook A14
 - ucm2: Qualcomm: add Lenovo ThinkBook 16 support
 - ucm2: Qualcomm: add HP Omnibook X14  support
 - USB-Audio: Add focusrite scarlett 18i20 lineup
 - USB-Audio: Add Roland BridgeCast One
 - sof-soundwire: cs42l43: Switch mixer based on output volume
 - ucm2: sof-soundwire: Correct include file path for dsp.conf
 - USB-Audio: ALC4080 - add rear microphone support for 0414:a014 (Gigabyte Aorus Pro)
 - sof-soundwire: Add LED support for cs35l56 amplifiers
 - sof-soundwire: cs42l43: Drop headset mic from mic mute LED
 - HDA: mics - don't create conflict link for Headphone Mic
 - HDA: mics - improve the Jack selection
 - HDA: mics - prefer 'Mic Jack' instead 'Headphone Jack'
 - USB-Audio: ALC4080 - add support for ASUS B850-I (USB ID 0b05:1be1)
 - sof-hda-dsp: Use common HDA initialization from /HDA/init.conf
 - HDA: move led.conf include to more appropriate place
 - ucm2: Qualcomm: fix typo in Lenovo T14s matching
 - sof-soundwire: rt1318: add playback control switch
 - ucm2: Qualcomm: add Lenovo Yoga Slim7x support
 - ucm2: Qualcomm: add Lenovo T14s support
 - ucm2: MediaTek: mt8390-evk: Add support for SOF
 - Torradex: replace spaces with tabs when appropriate
 - Torradex: fix wrong device names Headphone/Microphone
 - USB-Audio: Add support for RME Fireface UCX II
 - Qualcomm: Add QCS6490 RB3Gen2 HiFi config
 - Qualcomm: Add QCM6490 IDP HiFi config
 - ucm2: IO-Boards: Toradex: verdin: Add support for Toradex
 - ucm2: IO-Boards: Toradex: verdin: Add support for Toradex
 - ucm2: NXP: iMX6: Toradex: colibri-imx6: Add support for
 - ucm2: NXP: iMX7: Toradex: colibri-imx7: Add support for
 - ucm2: NXP: iMX8X: Toradex: colibri-imx8x: Add support for
 - ucm2: NXP: iMX6: Toradex: apalis-imx6: Add support for
 - ucm2: NXP: iMX8: Toradex: apalis-imx8: Add support for
 - ucm2: IO-Boards: Toradex: apalis: Add support for Toradex
 - USB-Audio: add Roland Quad-Capture support
 - ucm2: HDA - remove HDA-Capture-value.conf and put contents directly to HDACaptureDevice macro
 - ucm2: HDA: HiFi-analog/mic: Refactor the analog mic discovery
 - GoXLR: Add 'Broadcast Stream Mix 2' to Capture if channels
 - use SetLED in rt1318 init configuration
 - Turn speaker LED accroding to rt1318 speaker status
 - ucm2: use new SetLED macro to hide the implementation details
 - common: add led.conf with SetLED macro to hide implementation details
 - USB-Audio: Add support for TASCAM Model 12
 - UCM2: Blobs: SOF: Cleanup blob names from .blob to .bin
 - USB-Audio: alc4080: Add MSI PRO B650-A WIFI USB ID 0db0:9e6d
 - USB-Audio: Improve support for Focusrite 4th Gen devices
 - USB-Audio: GoXLR - fix the channel detection for mini, cleanups
 - USB-Audio: set capture channels to 4 in UR22C-HiFi.conf
 - sof-soundwire: Fix cs42l43 dmic initialisation
 - sof-soundwire: Split cs42l43 dmic initialisation
 - ucm2: add mt8183_mt6358_ts3a227_max98357
 - ucm2: add mt8183_da7219_rt1015p
 - ucm2: add acp3x-alc5682-alc1015
 - DEBUG.md: add "Logs from PipeWire (wireplumber)" section
 - USB-Audio: Revelator-IO-44-HiFi - fix device names (validator)
 - Rename ucm2/AMD/acp3xalc5682m98 to ucm2/AMD/acp3x-alc5682-max98357
 - Rename ucm2/AMD/acpd7219m98357 to ucm2/AMD/acp-da7219-rt5682-max98357
 - Qualcomm: Add SM8750 MTP HiFi config
 - rt722: change output volume of headphone to 0dB
 - ucm2: USB-Audio: add Presonus Revelator IO 44 (USB194f:0424)
 - USB-Audio: ALC4080 - add ASUS ROG Crosshair X870E Hero (USB ID 0b05:1b7c)
 - sun4i-codec: add routing for headphones and internal speaker
 - UCM2: sof-soundwire: Add setup of IIR, DRC, beamformer
 - UCM2: sof-soundwire: Add setup of IIR, DRC, beamformer
 - UCM2: sof-soundwire: Enable DRC and equalizers for
 - UCM2: Intel: sof-hda-dsp: Enable Dmic0 DRC and TDFB
 - UCM2: Blobs/SOF/IPC4: Add Beamformer blobs, update
 - UCM2: Intel: sof-hda-dsp: Cleanup definitions
 - UCM2: Intel: sof-hda-dsp: Move variables defitions from
 - ucm: fix SectionDevice identifiers
 - ucm2: whitespace fixes
 - USB-Audio: ALC4080: add support for MSI MEG X670E GODLIKE (USB 0db0:e1f8)
 - USB-Audio: ALC4080 - add ASUS ROG STRIX X870E-E GAMING WIFI (USB 0b05:1b9b)
 - Configuration files for Roland Bridge Cast X V2
 - ucm2: sof-soundwire: Correct FixedBootSequence for dmic info
 - amd-soundwire: add support for AMD generic legacy machine driver
 - sof-hda-dsp: Add back missing .conf suffix for product/user specific configs
 - sof-soundwire: whitespace cleanup
 - sof-soundwire: cs42l43: Correct CapturePCM and routing
 - avs_nau8825: Fix JackControl name
 - sof-soundwire: cs42l43-spk: Correct PlaybackPCM and routing
 - sof-hda-dsp: Fix the case where sysfs dmi product_name attribute is not set
 - UCM2: Intel: sof-hda-dsp: Fix handling of empty sys_vendor
Description
 - Release v1.2.14

Signed-off-by: Jaroslav Kysela <perex@perex.cz>
