### PR TITLE
bump: firmware-orangepi

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -336,6 +336,7 @@ menu "Firmwares"
 	source "$BR2_EXTERNAL_REGLINUX_PATH/package/firmwares/firmware-radxa-rkwifibt/Config.in"
 	source "$BR2_EXTERNAL_REGLINUX_PATH/package/firmwares/firmware-rk3588/Config.in"
 	source "$BR2_EXTERNAL_REGLINUX_PATH/package/firmwares/sound-open-firmware/Config.in"
+	source "$BR2_EXTERNAL_REGLINUX_PATH/package/firmwares/firmware-orangepi/Config.in"
 endmenu
 
 menu "Fonts"
@@ -407,7 +408,6 @@ endmenu
 
 menu "Firmwares"
 	source "$BR2_EXTERNAL_REGLINUX_PATH/package/batocera/firmwares/extralinuxfirmwares/Config.in"
-	source "$BR2_EXTERNAL_REGLINUX_PATH/package/batocera/firmwares/firmware-orangepi/Config.in"
 	source "$BR2_EXTERNAL_REGLINUX_PATH/package/batocera/firmwares/firmware-khadas-vim4/Config.in"
 endmenu
 

--- a/package/batocera/firmwares/firmware-orangepi/Config.in
+++ b/package/batocera/firmwares/firmware-orangepi/Config.in
@@ -1,4 +1,0 @@
-config BR2_PACKAGE_FIRMWARE_ORANGEPI
-	bool "firmware-orangepi"
-	help
-	  Orange Pi specific firmware

--- a/package/firmwares/firmware-orangepi/Config.in
+++ b/package/firmwares/firmware-orangepi/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_FIRMWARE_ORANGEPI
+	bool "firmware-orangepi"
+	help
+	  This package contains firmware files for Orange Pi devices.
+
+	  https://github.com/orangepi-xunlong/firmware

--- a/package/firmwares/firmware-orangepi/firmware-orangepi.mk
+++ b/package/firmwares/firmware-orangepi/firmware-orangepi.mk
@@ -3,8 +3,8 @@
 # firmware-orangepi
 #
 ################################################################################
-# Version.: Commits on Jun 2, 2023
-FIRMWARE_ORANGEPI_VERSION = d9c6dac6d934bd5923be573e99aac767681f2ca5
+# Version.: Commits on Mar 19, 2025
+FIRMWARE_ORANGEPI_VERSION = db5e86200ae592c467c4cfa50ec0c66cbc40b158
 FIRMWARE_ORANGEPI_SITE = $(call github,orangepi-xunlong,firmware,$(FIRMWARE_ORANGEPI_VERSION))
 
 FIRMWARE_ORANGEPI_TARGET_DIR=$(TARGET_DIR)/lib/firmware/


### PR DESCRIPTION
- Update ap6256 firmware
- Add ap6611s firmware
- Add rtl_nic firmware
- Add rtw89 firmware
- Add iwlwifi firmware
- Update aw87xxx_acf.bin
- Update BCM4362A2.hcd
- Add aic8800 firmware
- Add nvram_ap6256.txt-orangepirv2
