### PR TITLE
Remove dreamcast support from OpenGL ES 2 devices

### DIFF
--- a/package/system/reglinux-configgen/configs/configgen-defaults-bcm2836.yml
+++ b/package/system/reglinux-configgen/configs/configgen-defaults-bcm2836.yml
@@ -16,15 +16,6 @@ psx:
   options:
     gpu_software: true
     gfxbackend: Software
-atomiswave:
-  emulator: libretro
-  core:     flycastvl
-dreamcast:
-  emulator: libretro
-  core:     flycastvl
-naomi:
-  emulator: libretro
-  core:     flycastvl
 c64:
   emulator: libretro
   core:     vice_x64

--- a/package/system/reglinux-configgen/configs/configgen-defaults-bcm2837.yml
+++ b/package/system/reglinux-configgen/configs/configgen-defaults-bcm2837.yml
@@ -12,15 +12,6 @@ psx:
   options:
     gpu_software: true
     gfxbackend: Software
-atomiswave:
-  emulator: libretro
-  core:     flycastvl
-dreamcast:
-  emulator: libretro
-  core:     flycastvl
-naomi:
-  emulator: libretro
-  core:     flycastvl
 flash:
   emulator: lightspark
   core:     lightspark

--- a/package/system/reglinux-configgen/configs/configgen-defaults-cha.yml
+++ b/package/system/reglinux-configgen/configs/configgen-defaults-cha.yml
@@ -2,8 +2,6 @@ default:
   options:
     video_threaded: true
     smooth: false
-    retroarch.menu_driver: xmb
-    retroarch.audio_driver: alsathread
 
 mastersystem:
   emulator: libretro
@@ -11,18 +9,6 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     picodrive
-snes:
-  emulator: libretro
-  core:     snes9x
 fbneo:
   options:
     frameskip: auto
-atomiswave:
-  emulator: libretro
-  core:     flycast
-dreamcast:
-  emulator: libretro
-  core:     flycast
-naomi:
-  emulator: libretro
-  core:     flycast

--- a/package/system/reglinux-configgen/configs/configgen-defaults-h3.yml
+++ b/package/system/reglinux-configgen/configs/configgen-defaults-h3.yml
@@ -2,8 +2,6 @@ default:
   options:
     video_threaded: true
     smooth: false
-    retroarch.menu_driver: xmb
-    retroarch.audio_driver: alsathread
 
 mastersystem:
   emulator: libretro
@@ -11,41 +9,6 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     picodrive
-snes:
-  emulator: libretro
-  core:     snes9x
-c64:
-  emulator: libretro
-  core:     vice_x64
-c20:
-  emulator: libretro
-  core:     vice_xvic
-c128:
-  emulator: libretro
-  core:     vice_x128
-cplus4:
-  emulator: libretro
-  core:     vice_xplus4
-pet:
-  emulator: libretro
-  core:     vice_xpet
 fbneo:
   options:
     frameskip: auto
-fmtowns:
-  emulator: libretro
-  core:     mame
-atomiswave:
-  emulator: libretro
-  core:     flycast
-dreamcast:
-  emulator: libretro
-  core:     flycast
-naomi:
-  emulator: libretro
-  core:     flycast
-n64:
-  options:
-flash:
-  emulator: lightspark
-  core:     lightspark

--- a/package/system/reglinux-configgen/configs/configgen-defaults-h5.yml
+++ b/package/system/reglinux-configgen/configs/configgen-defaults-h5.yml
@@ -2,8 +2,6 @@ default:
   options:
     video_threaded: true
     smooth: false
-    retroarch.menu_driver: xmb
-    retroarch.audio_driver: alsathread
 
 mastersystem:
   emulator: libretro
@@ -32,21 +30,6 @@ cplus4:
 fmtowns:
   emulator: libretro
   core:     mame
-atomiswave:
-  emulator: flycast
-  core:     flycast
-dreamcast:
-  emulator: flycast
-  core:     flycast
-naomi:
-  emulator: flycast
-  core:     flycast
-naomi2:
-  emulator: flycast
-  core:     flycast
-systemsp:
-  emulator: flycast
-  core:     flycast
 fmtowns:
   emulator: libretro
   core:     mame

--- a/package/system/reglinux-configgen/configs/configgen-defaults-rk3326.yml
+++ b/package/system/reglinux-configgen/configs/configgen-defaults-rk3326.yml
@@ -8,12 +8,3 @@ nds:
 fmtowns:
   emulator: libretro
   core:     mame
-atomiswave:
-  emulator: libretro
-  core:     flycastvl
-dreamcast:
-  emulator: libretro
-  core:     flycastvl
-naomi:
-  emulator: libretro
-  core:     flycastvl

--- a/package/system/reglinux-system/Config.in.emulators
+++ b/package/system/reglinux-system/Config.in.emulators
@@ -35,23 +35,45 @@ config BR2_PACKAGE_REGLINUX_SEGADC
 	bool "REG-Linux dreamcast/naomi/atomiswave emulators/cores"
 
 	# Dreamcast / Naomi / Atomiswave emulation
-	select BR2_PACKAGE_FLYCAST		if !BR2_RISCV_64			&& \
-						   !BR2_mipsel				&& \
-						   !BR2_PACKAGE_SYSTEM_TARGET_BCM2836	&& \
-						   !BR2_PACKAGE_SYSTEM_TARGET_BCM2837	&& \
-						   !BR2_PACKAGE_SYSTEM_TARGET_RK3326
+    select BR2_PACKAGE_FLYCAST            if !BR2_RISCV_64                      && \
+                                             !BR2_mipsel                        && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_CHA     && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_H3      && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_H5      && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_BCM2835 && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_BCM2836 && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_BCM2837 && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_RK3128  && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_RK3328  && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_S812    && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_S905
 
-	select BR2_PACKAGE_LIBRETRO_FLYCAST	if !BR2_RISCV_64			&& \
-						   !BR2_mipsel				&& \
-						   !BR2_PACKAGE_SYSTEM_TARGET_BCM2836	&& \
-						   !BR2_PACKAGE_SYSTEM_TARGET_BCM2837	&& \
-						   !BR2_PACKAGE_SYSTEM_TARGET_RK3326
+    select BR2_PACKAGE_LIBRETRO_FLYCAST   if !BR2_RISCV_64                      && \
+                                             !BR2_mipsel                        && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_CHA     && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_H3      && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_H5      && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_H6      && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_H616    && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_H700    && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_BCM2835 && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_BCM2836 && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_BCM2837 && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_RK3128  && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_RK3326  && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_RK3328  && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_S9GEN4  && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_S812    && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_S905    && \
+                                             !BR2_PACKAGE_SYSTEM_TARGET_S905GEN2
 
-	select BR2_PACKAGE_LIBRETRO_FLYCASTVL	if BR2_PACKAGE_SYSTEM_TARGET_BCM2836	|| \
-						   BR2_PACKAGE_SYSTEM_TARGET_BCM2837	|| \
-						   BR2_PACKAGE_SYSTEM_TARGET_RK3326   || \
-						   BR2_PACKAGE_SYSTEM_TARGET_H3       || \
-						   BR2_PACKAGE_SYSTEM_TARGET_CHA
+    select BR2_PACKAGE_LIBRETRO_FLYCASTVL if BR2_PACKAGE_SYSTEM_TARGET_H6       || \
+                                             BR2_PACKAGE_SYSTEM_TARGET_H616     || \
+                                             BR2_PACKAGE_SYSTEM_TARGET_H700     || \
+                                             BR2_PACKAGE_SYSTEM_TARGET_RK3326   || \
+                                             BR2_PACKAGE_SYSTEM_TARGET_S9GEN4   || \
+                                             BR2_PACKAGE_SYSTEM_TARGET_S905GEN2
+
 
 	help
 	  Sega Dreamcast and Naomi/Atomiswave emulation support


### PR DESCRIPTION
Some Cortex-a53 / Cortex-a35 that support OpenGL ES 3 get flycast standalone + flycastvl libretro