### PR TITLE
Use compressed squashfs to store datainit files

### DIFF
--- a/board/fsoverlay/etc/init.d/S12populateshare
+++ b/board/fsoverlay/etc/init.d/S12populateshare
@@ -2,63 +2,30 @@
 
 case "$1" in
     start)
-        IN=/usr/share/reglinux/datainit
-        OUT=/userdata
+        TOTALSTEPS=0
+        CURRENTSTEP=0
 
-        rm -f /tmp/updateuserdata.lst # Make sure we start with an empty list
-
-        # Directories deleted by user will be recreated when booting
-        # the user can delete the content or add its own files
-        # to reset the directory or update it, the user has to remove the directory
+        # Directories deleted by user will be recreated when booting.
+        # The user can delete the content or add its own files.
+        # To reset the directory or update it, the user has to remove the directory
         # (we are unable to differenciate new files from REG-linux update from a file removed by the user)
 
-        # Get a list of folders (or files) that do not yet exist in /userdata
-        grep -Fvx -f <(cd "$OUT" || exit; find ./ -mindepth 1 -maxdepth 1 -type d) <(cd "$IN" || exit; find ./ -mindepth 1 -maxdepth 1 -type d) >> /tmp/updateuserdata.lst
-
-        if [ -d "$OUT"/roms ]; then
-            grep -Fvx -f <(cd "$OUT" || exit; find ./roms -mindepth 1 -maxdepth 1 -type d) <(cd "$IN" || exit; find ./roms -mindepth 1 -maxdepth 1 -type d) >> /tmp/updateuserdata.lst
-        fi
-        if [ -d "$OUT"/roms/mame ]; then
-            mkdir -p "$OUT"/roms/mame/mame2003
-            grep -Fvx -f <(cd "$OUT" || exit; find ./roms/mame/mame2003 \( -type f -o -xtype l \)) <(cd "$IN" || exit; find ./roms/mame/mame2003 \( -type f -o -xtype l \)) >> /tmp/updateuserdata.lst
-        fi
-        if [ -d "$OUT"/system ]; then
-            grep -Fvx -f <(cd "$OUT" || exit; find ./system -mindepth 1 -maxdepth 1) <(cd "$IN" || exit; find ./system -mindepth 1 -maxdepth 1) >> /tmp/updateuserdata.lst
-        fi
-
-        # USUALLY ONLY NEW DIRECTORIES ARE UPDATED WHEN REG-LINUX IS UPDATED
-        # but sometimes we update _info.txt, readme.txt, bios or other files.
-        CURVERSION=$(cat /usr/share/reglinux/system.version)
-        SHAREVERSION=$(cat /userdata/system/data.version 2>/dev/null)
-
-        if [ "$CURVERSION" != "$SHAREVERSION" ]; then
-            cd "$IN" || exit
-
-            # Get everything, we'll use "cp -rfu"
-            # -maxdepth 3 because we need to look for ./roms/mame/mame2003/*folderswithgames*/_info.txt
-            if [ -d "$OUT"/roms ]; then
-                find ./roms -mindepth 1 -maxdepth 3 \( -type f -o -xtype l \) \( -iname "_info.txt" -o -iname "readme.txt" \) >> /tmp/updateuserdata.lst
+        while read -r files; do
+            if [[ -n "$files" ]] && [[ -e "/userdata/$files" ]]; then
+                EMPTYSHARE=n
+            else
+                LIST="$files $LIST"
             fi
+        done < /usr/share/reglinux/datainit.list
 
-            # Also update bios if needed
-            if [ -d "$OUT"/bios ]; then
-                find ./bios \( -type f -o -xtype l \) >> /tmp/updateuserdata.lst
-            fi
-            if [ -d "$OUT"/roms/iortcw ]; then
-                find ./roms/iortcw/main \( -type f -o -xtype l \) >> /tmp/updateuserdata.lst
-            fi
-
-            # And REG-linux system configs, services but do not update user settings.
-            if [ -d "$OUT"/system ]; then
-                find ./system \( -type f -o -xtype l \) \( ! -iname "es_settings.cfg" -a ! -iname "gamecontrollerdb.txt" -a ! -iname "system.conf" \) >> /tmp/updateuserdata.lst
-            fi
+        if [[ -n "$EMPTYSHARE" ]] && [[ "$(head -n1 /usr/share/reglinux/system.version 2>/dev/null)" != "$(head -n1 /userdata/system/data.version 2>/dev/null)" ]]; then
+            # Update some files but not overwrite user configs
+            LIST="$LIST '/roms/*/_info.txt' '*/readme.txt' 'bios/' 'roms/iortcw/main/' 'system/'"
+            EXCLUDELIST="-ex '... gamecontrollerdb.txt' '... system.conf' '... es_settings.cfg' \; "
         fi
 
-        CURRENTSTEP=0
-        TOTALSTEPS=$(grep -c ".*" /tmp/updateuserdata.lst 2>/dev/null || echo "0")
-        if [ "$TOTALSTEPS" -gt 0 ]; then
-
-            ((TOTALSTEPS+=4))           # Add the last steps to correctly show progress bar
+        if [[ -n "$LIST" ]]; then
+            ((TOTALSTEPS+=3))           # Add the last steps to correctly show progress bar
             ((CURRENTSTEP+=100))        # STEP * 100 for percentage
 
             # Start UPDATING splash
@@ -67,23 +34,26 @@ case "$1" in
             else
                 /usr/bin/plymouth change-mode --updates
             fi
-            /usr/bin/plymouth --show-splash
             /usr/bin/plymouth system-update --progress "$((CURRENTSTEP / TOTALSTEPS))"
-            /usr/bin/plymouth display-message --text="Creating missing folders"
 
-            # Create needed folders in /userdata
-            sed 's#/[^/]*$##;/^\.$/d;s#^\./##' /tmp/updateuserdata.lst | sort -u |
-                while IFS= read -r SUBDIR; do
-                    mkdir -p "${OUT}/$SUBDIR"
-                done
+            mkdir -p /userdata/system/logs
+            if [[ -n "$EMPTYSHARE" ]]; then
+                /usr/bin/plymouth display-message --text="Updating BIOS and other files in /userdata"
+                echo "Updating BIOS and other files in /userdata" >/userdata/system/logs/extracted.files.log
+                echo "unsquashfs -f -d /userdata $EXCLUDELIST /usr/share/reglinux/datainit.squashfs $LIST" >>/userdata/system/logs/extracted.files.log
+                echo >>/userdata/system/logs/extracted.files.log
+                eval "unsquashfs -f -i -d /userdata $EXCLUDELIST /usr/share/reglinux/datainit.squashfs $LIST" &>>/userdata/system/logs/extracted.files.log
+            else
+                # Partition is "empty", just extract everything
+                /usr/bin/plymouth display-message --text="Extracting files to /userdata"
+                echo "Extracting files to /userdata" >/userdata/system/logs/extracted.files.log
+                echo "unsquashfs -f -d /userdata /usr/share/reglinux/datainit.squashfs" >>/userdata/system/logs/extracted.files.log
+                echo >>/userdata/system/logs/extracted.files.log
+                unsquashfs -f -i -d /userdata /usr/share/reglinux/datainit.squashfs &>>/userdata/system/logs/extracted.files.log
+            fi
 
-            # Copy files
-            while IFS= read -r FILE; do
-                ((CURRENTSTEP+=100))
-                /usr/bin/plymouth system-update --progress "$((CURRENTSTEP / TOTALSTEPS))"
-                /usr/bin/plymouth display-message --text="Copying files: $FILE"
-                cp -rfu "${IN}/$FILE" "${OUT}/${FILE%/*}/"
-            done < <(sed 's#^\./##' /tmp/updateuserdata.lst)
+            # Save to avoid to redo some steps every boot
+            cp /usr/share/reglinux/system.version /userdata/system/data.version
 
             ((CURRENTSTEP+=100))
             /usr/bin/plymouth system-update --progress "$((CURRENTSTEP / TOTALSTEPS))"
@@ -100,12 +70,10 @@ case "$1" in
         ln -sf /userdata/system/machine-id /var/lib/dbus/machine-id
         ln -sf /userdata/system/machine-id /etc/machine-id
 
-        # Save to avoid to redo some steps every boot
-        [ "$CURVERSION" != "$SHAREVERSION" ] && cp /usr/share/reglinux/system.version /userdata/system/data.version
-
         # call user script with start condition
         if [ -e /boot/postshare.sh ]; then
             if [ "$TOTALSTEPS" -gt 0 ]; then
+                ((TOTALSTEPS++))
                 ((CURRENTSTEP+=100))
                 /usr/bin/plymouth system-update --progress "$((CURRENTSTEP / TOTALSTEPS))"
                 /usr/bin/plymouth display-message --text="Running postshare script"

--- a/custom/fs/common.mk
+++ b/custom/fs/common.mk
@@ -1,0 +1,230 @@
+#
+# Macro that builds the needed Makefile target to create a root
+# filesystem image.
+#
+# The following variable must be defined before calling this macro
+#
+#  ROOTFS_$(FSTYPE)_CMD, the command that generates the root
+#  filesystem image. A single command is allowed. The filename of the
+#  filesystem image that it must generate is $$@.
+#
+# The following variables can optionaly be defined
+#
+#  ROOTFS_$(FSTYPE)_DEPENDENCIES, the list of dependencies needed to
+#  build the root filesystem (usually host tools)
+#
+#  ROOTFS_$(FSTYPE)_PRE_GEN_HOOKS, a list of hooks to call before
+#  generating the filesystem image
+#
+#  ROOTFS_$(FSTYPE)_POST_GEN_HOOKS, a list of hooks to call after
+#  generating the filesystem image
+#
+# In terms of configuration option, this macro assumes that the
+# BR2_TARGET_ROOTFS_$(FSTYPE) config option allows to enable/disable
+# the generation of a filesystem image of a particular type. If
+# the configuration options BR2_TARGET_ROOTFS_$(FSTYPE)_GZIP,
+# BR2_TARGET_ROOTFS_$(FSTYPE)_BZIP2 or
+# BR2_TARGET_ROOTFS_$(FSTYPE)_LZMA exist and are enabled, then the
+# macro will automatically generate a compressed filesystem image.
+
+FS_DIR = $(BUILD_DIR)/buildroot-fs
+ROOTFS_DEVICE_TABLES = $(call qstrip,$(BR2_ROOTFS_DEVICE_TABLE) \
+	$(BR2_ROOTFS_STATIC_DEVICE_TABLE))
+
+ROOTFS_USERS_TABLES = $(call qstrip,$(BR2_ROOTFS_USERS_TABLES))
+
+ROOTFS_FULL_DEVICES_TABLE = $(FS_DIR)/full_devices_table.txt
+ROOTFS_FULL_USERS_TABLE = $(FS_DIR)/full_users_table.txt
+
+ROOTFS_COMMON_NAME = rootfs-common
+ROOTFS_COMMON_TYPE = rootfs
+ROOTFS_COMMON_DEPENDENCIES = \
+	host-fakeroot host-makedevs \
+	$(BR2_TAR_HOST_DEPENDENCY) \
+	$(if $(PACKAGES_USERS)$(ROOTFS_USERS_TABLES),host-mkpasswd)
+
+ifeq ($(BR2_REPRODUCIBLE),y)
+define ROOTFS_REPRODUCIBLE
+	find $(TARGET_DIR) -print0 | xargs -0 -r touch -hd @$(SOURCE_DATE_EPOCH)
+endef
+endif
+
+ifeq ($(BR2_PACKAGE_REFPOLICY),y)
+define ROOTFS_SELINUX
+	$(HOST_DIR)/sbin/setfiles -m -r $(TARGET_DIR) \
+		-c $(TARGET_DIR)/etc/selinux/targeted/policy/policy.$(BR2_PACKAGE_LIBSEPOL_POLICY_VERSION) \
+		$(TARGET_DIR)/etc/selinux/targeted/contexts/files/file_contexts \
+		$(TARGET_DIR)
+endef
+ROOTFS_COMMON_DEPENDENCIES += host-policycoreutils
+endif
+
+ROOTFS_COMMON_FINAL_RECURSIVE_DEPENDENCIES = $(sort \
+	$(if $(filter undefined,$(origin ROOTFS_COMMON_FINAL_RECURSIVE_DEPENDENCIES__X)), \
+		$(eval ROOTFS_COMMON_FINAL_RECURSIVE_DEPENDENCIES__X := \
+			$(foreach p, \
+				$(ROOTFS_COMMON_DEPENDENCIES), \
+				$(p) \
+				$($(call UPPERCASE,$(p))_FINAL_RECURSIVE_DEPENDENCIES) \
+			) \
+		) \
+	) \
+	$(ROOTFS_COMMON_FINAL_RECURSIVE_DEPENDENCIES__X))
+
+.PHONY: rootfs-common
+rootfs-common: $(ROOTFS_COMMON_DEPENDENCIES) target-finalize
+	@$(call MESSAGE,"Generating root filesystems common tables")
+	rm -rf $(FS_DIR)
+	mkdir -p $(FS_DIR)
+
+	$(call PRINTF,$(PACKAGES_USERS)) >> $(ROOTFS_FULL_USERS_TABLE)
+ifneq ($(ROOTFS_USERS_TABLES),)
+	cat $(ROOTFS_USERS_TABLES) >> $(ROOTFS_FULL_USERS_TABLE)
+endif
+
+	$(call PRINTF,$(PACKAGES_PERMISSIONS_TABLE)) > $(ROOTFS_FULL_DEVICES_TABLE)
+ifneq ($(ROOTFS_DEVICE_TABLES),)
+	cat $(ROOTFS_DEVICE_TABLES) >> $(ROOTFS_FULL_DEVICES_TABLE)
+endif
+ifeq ($(BR2_ROOTFS_DEVICE_CREATION_STATIC),y)
+	$(call PRINTF,$(PACKAGES_DEVICES_TABLE)) >> $(ROOTFS_FULL_DEVICES_TABLE)
+endif
+
+rootfs-common-show-depends:
+	@echo $(ROOTFS_COMMON_DEPENDENCIES)
+
+.PHONY: rootfs-common-show-info
+rootfs-common-show-info:
+	@:
+	$(info $(call clean-json,{ $(call json-info,ROOTFS_COMMON) }))
+
+# Since this function will be called from within an $(eval ...)
+# all variable references except the arguments must be $$-quoted.
+define inner-rootfs
+
+ROOTFS_$(2)_NAME = rootfs-$(1)
+ROOTFS_$(2)_TYPE = rootfs
+ROOTFS_$(2)_IMAGE_NAME ?= rootfs.$(1)
+ROOTFS_$(2)_FINAL_IMAGE_NAME = $$(strip $$(ROOTFS_$(2)_IMAGE_NAME))
+ROOTFS_$(2)_DIR = $$(FS_DIR)/$(1)
+ROOTFS_$(2)_TARGET_DIR = $$(ROOTFS_$(2)_DIR)/target
+
+ROOTFS_$(2)_DEPENDENCIES += rootfs-common
+
+ROOTFS_$(2)_FINAL_RECURSIVE_DEPENDENCIES = $$(sort \
+	$$(if $$(filter undefined,$$(origin ROOTFS_$(2)_FINAL_RECURSIVE_DEPENDENCIES__X)), \
+		$$(eval ROOTFS_$(2)_FINAL_RECURSIVE_DEPENDENCIES__X := \
+			$$(foreach p, \
+				$$(ROOTFS_$(2)_DEPENDENCIES), \
+				$$(p) \
+				$$($$(call UPPERCASE,$$(p))_FINAL_RECURSIVE_DEPENDENCIES) \
+			) \
+		) \
+	) \
+	$$(ROOTFS_$(2)_FINAL_RECURSIVE_DEPENDENCIES__X))
+
+ifeq ($$(BR2_TARGET_ROOTFS_$(2)_GZIP),y)
+ROOTFS_$(2)_COMPRESS_EXT = .gz
+ROOTFS_$(2)_COMPRESS_CMD = gzip -9 -c -n
+endif
+ifeq ($$(BR2_TARGET_ROOTFS_$(2)_BZIP2),y)
+ROOTFS_$(2)_COMPRESS_EXT = .bz2
+ROOTFS_$(2)_COMPRESS_CMD = bzip2 -9 -c
+endif
+ifeq ($$(BR2_TARGET_ROOTFS_$(2)_LZMA),y)
+ROOTFS_$(2)_DEPENDENCIES += host-lzma
+ROOTFS_$(2)_COMPRESS_EXT = .lzma
+ROOTFS_$(2)_COMPRESS_CMD = $$(LZMA) -9 -c
+endif
+ifeq ($$(BR2_TARGET_ROOTFS_$(2)_LZ4),y)
+ROOTFS_$(2)_DEPENDENCIES += host-lz4
+ROOTFS_$(2)_COMPRESS_EXT = .lz4
+ROOTFS_$(2)_COMPRESS_CMD = lz4 -l -9 -c
+endif
+ifeq ($$(BR2_TARGET_ROOTFS_$(2)_LZO),y)
+ROOTFS_$(2)_DEPENDENCIES += host-lzop
+ROOTFS_$(2)_COMPRESS_EXT = .lzo
+ROOTFS_$(2)_COMPRESS_CMD = $$(LZOP) -9 -c
+endif
+ifeq ($$(BR2_TARGET_ROOTFS_$(2)_XZ),y)
+ROOTFS_$(2)_DEPENDENCIES += host-xz
+ROOTFS_$(2)_COMPRESS_EXT = .xz
+ROOTFS_$(2)_COMPRESS_CMD = xz -9 -C crc32 -c
+ifeq ($(BR2_REPRODUCIBLE),)
+ROOTFS_$(2)_COMPRESS_CMD += -T $(PARALLEL_JOBS)
+endif
+endif
+ifeq ($(BR2_TARGET_ROOTFS_$(2)_ZSTD),y)
+ROOTFS_$(2)_DEPENDENCIES += host-zstd
+ROOTFS_$(2)_COMPRESS_EXT = .zst
+ROOTFS_$(2)_COMPRESS_CMD = zstd -19 -z -f -T$(PARALLEL_JOBS)
+endif
+
+$$(BINARIES_DIR)/$$(ROOTFS_$(2)_FINAL_IMAGE_NAME): ROOTFS=$(2)
+$$(BINARIES_DIR)/$$(ROOTFS_$(2)_FINAL_IMAGE_NAME): FAKEROOT_SCRIPT=$$(ROOTFS_$(2)_DIR)/fakeroot
+$$(BINARIES_DIR)/$$(ROOTFS_$(2)_FINAL_IMAGE_NAME): $$(ROOTFS_$(2)_DEPENDENCIES)
+	@$$(call MESSAGE,"Generating filesystem image $$(ROOTFS_$(2)_FINAL_IMAGE_NAME)")
+	mkdir -p $$(@D)
+	rm -rf $$(ROOTFS_$(2)_DIR)
+	mkdir -p $$(ROOTFS_$(2)_DIR)
+	rsync -auH \
+		--exclude=/$$(notdir $$(TARGET_DIR_WARNING_FILE)) \
+		--exclude=/usr/share/reglinux/datainit \
+		$$(BASE_TARGET_DIR)/ \
+		$$(TARGET_DIR)
+
+	echo '#!/bin/sh' > $$(FAKEROOT_SCRIPT)
+	echo "set -e" >> $$(FAKEROOT_SCRIPT)
+
+	echo "chown -h -R 0:0 $$(TARGET_DIR)" >> $$(FAKEROOT_SCRIPT)
+	PATH=$$(BR_PATH) $$(TOPDIR)/support/scripts/mkusers $$(ROOTFS_FULL_USERS_TABLE) $$(TARGET_DIR) >> $$(FAKEROOT_SCRIPT)
+	echo "$$(HOST_DIR)/bin/makedevs -d $$(ROOTFS_FULL_DEVICES_TABLE) $$(TARGET_DIR)" >> $$(FAKEROOT_SCRIPT)
+	$$(foreach hook,$$(ROOTFS_PRE_CMD_HOOKS),\
+		$$(call PRINTF,$$($$(hook))) >> $$(FAKEROOT_SCRIPT)$$(sep))
+	$$(foreach s,$$(call qstrip,$$(BR2_ROOTFS_POST_FAKEROOT_SCRIPT)),\
+		echo "echo '$$(TERM_BOLD)>>>   Executing fakeroot script $$(s)$$(TERM_RESET)'" >> $$(FAKEROOT_SCRIPT); \
+		echo $$(EXTRA_ENV) $$(s) $$(TARGET_DIR) $$(BR2_ROOTFS_POST_SCRIPT_ARGS) $$(BR2_ROOTFS_POST_FAKEROOT_SCRIPT_ARGS) >> $$(FAKEROOT_SCRIPT)$$(sep))
+
+	$$(foreach hook,$$(ROOTFS_$(2)_PRE_GEN_HOOKS),\
+		$$(call PRINTF,$$($$(hook))) >> $$(FAKEROOT_SCRIPT)$$(sep))
+	echo "find $$(TARGET_DIR)/run/ -mindepth 1 -prune -print0 | xargs -0r rm -rf --" >> $$(FAKEROOT_SCRIPT)
+	echo "find $$(TARGET_DIR)/tmp/ -mindepth 1 -prune -print0 | xargs -0r rm -rf --" >> $$(FAKEROOT_SCRIPT)
+	$$(call PRINTF,$$(ROOTFS_REPRODUCIBLE)) >> $$(FAKEROOT_SCRIPT)
+	$$(call PRINTF,$$(ROOTFS_SELINUX)) >> $$(FAKEROOT_SCRIPT)
+	$$(call PRINTF,$$(ROOTFS_$(2)_CMD)) >> $$(FAKEROOT_SCRIPT)
+	chmod a+x $$(FAKEROOT_SCRIPT)
+	PATH=$$(BR_PATH) FAKEROOTDONTTRYCHOWN=1 $$(HOST_DIR)/bin/fakeroot -- $$(FAKEROOT_SCRIPT)
+	$(Q)rm -rf $$(TARGET_DIR)
+ifneq ($$(ROOTFS_$(2)_COMPRESS_CMD),)
+	PATH=$$(BR_PATH) $$(ROOTFS_$(2)_COMPRESS_CMD) $$@ > $$@$$(ROOTFS_$(2)_COMPRESS_EXT)
+endif
+	$$(foreach hook,$$(ROOTFS_$(2)_POST_GEN_HOOKS),$$(call $$(hook))$$(sep))
+
+rootfs-$(1)-show-depends:
+	@echo $$(ROOTFS_$(2)_DEPENDENCIES)
+
+rootfs-$(1)-show-info:
+	@:
+	$$(info $$(call clean-json,{ $$(call json-info,ROOTFS_$(2)) }))
+
+rootfs-$(1): $$(BINARIES_DIR)/$$(ROOTFS_$(2)_FINAL_IMAGE_NAME)
+
+.PHONY: rootfs-$(1) rootfs-$(1)-show-depends rootfs-$(1)-show-info
+
+ifeq ($$(BR2_TARGET_ROOTFS_$(2)),y)
+TARGETS_ROOTFS += rootfs-$(1)
+PACKAGES += $$(filter-out rootfs-%,$$(ROOTFS_$(2)_FINAL_RECURSIVE_DEPENDENCIES))
+endif
+
+# Check for legacy POST_TARGETS rules
+ifneq ($$(ROOTFS_$(2)_POST_TARGETS),)
+$$(error Filesystem $(1) uses post-target rules, which are no longer supported.\
+	Update $(1) to use post-gen hooks instead)
+endif
+
+endef
+
+# $(pkgname) also works well to return the filesystem name
+rootfs = $(call inner-rootfs,$(pkgname),$(call UPPERCASE,$(pkgname)))
+
+include $(sort $(wildcard fs/*/*.mk))

--- a/custom/fs/common.mk.patch
+++ b/custom/fs/common.mk.patch
@@ -1,0 +1,12 @@
+diff --git a/fs/common.mk b/fs/common.mk
+index 2f3f8bcc7e..bb4da3d882 100644
+--- a/fs/common.mk
++++ b/fs/common.mk
+@@ -169,6 +169,7 @@ $$(BINARIES_DIR)/$$(ROOTFS_$(2)_FINAL_IMAGE_NAME): $$(ROOTFS_$(2)_DEPENDENCIES)
+ 	mkdir -p $$(ROOTFS_$(2)_DIR)
+ 	rsync -auH \
+ 		--exclude=/$$(notdir $$(TARGET_DIR_WARNING_FILE)) \
++		--exclude=/usr/share/reglinux/datainit \
+ 		$$(BASE_TARGET_DIR)/ \
+ 		$$(TARGET_DIR)
+ 

--- a/custom/list.hash
+++ b/custom/list.hash
@@ -21,6 +21,7 @@
 f2484cdc4239f8323b2b3d7c4fb74469  Makefile
 d5729e1c36bf284009e995bd4dc86d73  arch/Config.in.arm
 27079cca2e6570dffdb72cd5c79cf026  boot/syslinux/syslinux.mk
+8ed1a372ecb4b8609821e71f4a5b2966  fs/common.mk
 13c7f1897975ae6d698aa3eda525d125  fs/cpio/dracut.conf
 68b27177f9fe560b74f0c9e4c4fd53e1  fs/cpio/init
 0f1e375992de585df0580c9ef85158e8  fs/squashfs/Config.in


### PR DESCRIPTION
- Exclude /usr/share/reglinux/datainit from final img (it is ignored, not deleted from build folders);
- Replace previous folder with compressed file (/usr/share/reglinux/datainit.squashfs);
- Include list of important paths for faster verification (/usr/share/reglinux/datainit.list).