### PR TITLE
Remove underscore at the end of model name

### DIFF
--- a/package/batocera/core/batocera-settings/system-settings-get-master
+++ b/package/batocera/core/batocera-settings/system-settings-get-master
@@ -1,63 +1,53 @@
-#!/bin/sh
+#!/bin/bash
 
-# this script can be used by values that can have a default value by board
+# this script can be used to get values that can have a default value by board
 
 KEY=
 CONFFILE=
 SYSCONFFILE="/usr/share/reglinux/sysconfigs/system.conf"
 
-while test $# -ne 0
+while [ $# -ne 0 ]
 do
     case "${1}" in
-	"-f")
-	    shift
-	    CONFFILE="${1}"
-	    shift
-	    ;;
-	*)
-	    KEY="${1}"
-	    shift
+    "-f")
+        shift
+        CONFFILE="${1}"
+        shift
+        ;;
+    *)
+        KEY="${1}"
+        shift
     esac
 done
 
 # prefer the user value
 if [ -n "${CONFFILE}" ]; then
-    VALUE="$(/usr/bin/system-settings-get -f "${CONFFILE}" "${KEY}")"
+    VALUE="$(/usr/bin/system-settings-get -f "${CONFFILE}" "${KEY}" 2>/dev/null)"
 else
-    VALUE="$(/usr/bin/system-settings-get "${KEY}")"
+    VALUE="$(/usr/bin/system-settings-get "${KEY}" 2>/dev/null)"
 fi
 # when value is auto, ignore
-if [ "$?" = 0 -a "${VALUE}" != "auto" ]; then
+if [ -n "${VALUE}" ] && [ "${VALUE}" != "auto" ]; then
     echo "${VALUE}"
     exit 0
 fi
 
-if [ -f /sys/firmware/devicetree/base/model ]; then
-    IFS= read -r BOARD_MODEL </sys/firmware/devicetree/base/model
-fi
-if [ -z "${BOARD_MODEL}" -a -f /sys/devices/virtual/dmi/id/product_name ]; then
-    # give an other chance with dmi
-    IFS= read -r BOARD_MODEL </sys/devices/virtual/dmi/id/product_name
-fi
-BOARD_MODEL="$(echo "$BOARD_MODEL" | sed -e s+"[^A-Za-z0-9]"+"_"+g)"
-# fall back to board name if product name is not ideal
-if [ -z "${BOARD_MODEL}" ] || [ "${BOARD_MODEL}" = "Default_string" ]; then
-    BOARD_MODEL=$(cat /sys/devices/virtual/dmi/id/board_name 2>/dev/null | tr -d '\0' | sed -e s+"[^A-Za-z0-9]"+"_"+g)
+BOARD_MODEL=$(tr -d '\0' </sys/firmware/devicetree/base/model 2>/dev/null)
+[ -z "${BOARD_MODEL}" ] && BOARD_MODEL=$(tr -d '\0' </sys/devices/virtual/dmi/id/product_name 2>/dev/null)
+# 3rd time lucky
+if [ -z "${BOARD_MODEL}" ] || [ "${BOARD_MODEL}" = "Default string" ]; then
+    BOARD_MODEL=$(tr -d '\0' </sys/devices/virtual/dmi/id/board_name 2>/dev/null)
 fi
 
 # prefer the board value
-if [ -e "${SYSCONFFILE}.${BOARD_MODEL}" ]; then
-    VALUE="$(/usr/bin/system-settings-get -f "${SYSCONFFILE}.${BOARD_MODEL}" "${KEY}")"
-    # when value is auto, ignore
-    if [ "$?" = 0 -a "${VALUE}" != "auto" ]; then
-        echo "${VALUE}"
-        exit 0
-    fi
+VALUE="$(/usr/bin/system-settings-get -f "${SYSCONFFILE}.${BOARD_MODEL//[^[:alnum:]]/_}" "${KEY}" 2>/dev/null)"
+# when value is auto, ignore
+if [ -n "${VALUE}" ] && [ "${VALUE}" != "auto" ]; then
+    echo "${VALUE}"
+    exit 0
 fi
 
-# prefer the general value
-if [ -e "${SYSCONFFILE}" ]; then
-    /usr/bin/system-settings-get -f "${SYSCONFFILE}" "${KEY}" && exit 0
-fi
+# fall back to the general value
+/usr/bin/system-settings-get -f "${SYSCONFFILE}" "${KEY}" 2>/dev/null && exit 0
 
 exit 1

--- a/package/system/reglinux-scripts/scripts/system-info
+++ b/package/system/reglinux-scripts/scripts/system-info
@@ -1,11 +1,7 @@
 #!/bin/bash
 
 ### full version (not on login, otherwise you can't log when OpenGL/Vulkan are out of order)
-if test "$1" = "--full"; then
-	FULL_DISPLAY=1
-else
-	FULL_DISPLAY=0
-fi
+[ "$1" = "--full" ] && FULL_DISPLAY=1 || FULL_DISPLAY=0
 ###
 
 # Detect battery
@@ -44,23 +40,17 @@ if [ -n "${BATTERY_DIR}" ]; then
 fi
 
 ### short version (for osd)
-if test "$1" = "--short"; then
+if [ "$1" = "--short" ]; then
     DT=$(date +%H:%M)
-    if test -n "${BATT}"; then
-        echo "Battery: ${BATT}%${BATTREMAINING} - ${DT}"
-    else
-        echo "${DT}"
-    fi
+    [ -n "${BATT}" ] && echo "Battery: ${BATT}%${BATTREMAINING} - ${DT}" || echo "${DT}"
     exit 0
 fi
 ###
 
 V_BOARD=$(cat /boot/boot/system.board)
 V_CPUNB=$(LANG=C lscpu | sed -n -e '/.*Core(s) per socket:[ ]*\(.*\)/{s//\1/p;:a' -e '$!N;$!ba' -e '}')
-if test -z "${V_CPUNB}"; then
-    # give an other chance
-    V_CPUNB=$(LANG=C lscpu | sed -n -e '/.*Core(s) per cluster:[ ]*\(.*\)/{s//\1/p;:a' -e '$!N;$!ba' -e '}')
-fi
+[ -z "${V_CPUNB}" ] && V_CPUNB=$(LANG=C lscpu | sed -n -e '/.*Core(s) per cluster:[ ]*\(.*\)/{s//\1/p;:a' -e '$!N;$!ba' -e '}')
+
 V_CPUMAXNB=$(LANG=C lscpu | sed -n -e 's|^CPU(s):[ ]*\(.*\)|\1|p')
 V_CPUMODEL1=$(sed -n -e '/^model name\t\: \(.*\)/{s//\1/p;:a' -e '$!N;$!ba' -e '}' /proc/cpuinfo 2>/dev/null)
 V_SYSTEM=$(uname -rs)
@@ -78,40 +68,30 @@ done
 V_CPUMINFREQ=$((V_CPUMINFREQ/1000))
 V_CPUMAXFREQ=$((V_CPUMAXFREQ/1000))
 
-V_BOARD_MODEL=$(sed -e 's|[^A-Za-z0-9]|_|g' /sys/firmware/devicetree/base/model 2>/dev/null)
-[ -z "${V_BOARD_MODEL}" ] && V_BOARD_MODEL=$(sed -e 's|[^A-Za-z0-9]|_|g' /sys/devices/virtual/dmi/id/product_name 2>/dev/null)
+V_BOARD_MODEL=$(tr -d '\0' </sys/firmware/devicetree/base/model 2>/dev/null)
+[ -z "${V_BOARD_MODEL}" ] && V_BOARD_MODEL=$(tr -d '\0' </sys/devices/virtual/dmi/id/product_name 2>/dev/null)
 # 3rd time lucky
-if test -z "${V_BOARD_MODEL}" || test "${V_BOARD_MODEL}" == "Default_string"; then
-    V_BOARD_MODEL=$(sed -e 's|[^A-Za-z0-9]|_|g' /sys/devices/virtual/dmi/id/board_name 2>/dev/null)
+if [ -z "${V_BOARD_MODEL}" ] || [ "${V_BOARD_MODEL}" = "Default string" ]; then
+    V_BOARD_MODEL=$(tr -d '\0' </sys/devices/virtual/dmi/id/board_name 2>/dev/null)
 fi
-if test -n "${V_BOARD_MODEL}"; then
-    echo "Model: ${V_BOARD_MODEL}"
-fi
+[ -n "${V_BOARD_MODEL}" ] && echo "Model: ${V_BOARD_MODEL//[^[:alnum:]]/_}"
+
 echo "System: ${V_SYSTEM}"
+
 V_ARCH=$(uname -m)
 echo "Architecture: ${V_ARCH}"
-if [ "$V_BOARD" != "$V_ARCH" ]; then
-    echo "Board: ${V_BOARD}"
-fi
+[ "$V_BOARD" != "$V_ARCH" ] && echo "Board: ${V_BOARD}"
 
 if [ -z "${V_BOARD#rpi[0-9]}" ]; then
     REVISION=$(sed -n -e 's|^Revision\t: \(.*\)$|\1|p' /proc/cpuinfo 2>/dev/null)
-    test -n "${REVISION}" && echo "Revision: ${REVISION}"
+    [ -n "${REVISION}" ] && echo "Revision: ${REVISION}"
 fi
 
-[[ -z ${V_CPUMODEL1} ]] || echo "CPU Model: ${V_CPUMODEL1}"
+[ -n "${V_CPUMODEL1}" ] && echo "CPU Model: ${V_CPUMODEL1}"
 
-if test "${V_CPUMAXNB}" = "${V_CPUNB}"; then
-    echo "CPU Cores: ${V_CPUNB}"
-else
-    echo "CPU Cores: ${V_CPUNB} / CPU Threads: ${V_CPUMAXNB}"
-fi
+[ "${V_CPUMAXNB}" = "${V_CPUNB}" ] && echo "CPU Cores: ${V_CPUNB}" || echo "CPU Cores: ${V_CPUNB} / CPU Threads: ${V_CPUMAXNB}"
 
-if test "${V_CPUMINFREQ}" != "${V_CPUMAXFREQ}"; then
-    echo "CPU Frequency: ${V_CPUMINFREQ}/${V_CPUMAXFREQ} MHz"
-else
-    echo "CPU Max Frequency: ${V_CPUMAXFREQ} MHz"
-fi
+[ "${V_CPUMINFREQ}" != "${V_CPUMAXFREQ}" ] && echo "CPU Frequency: ${V_CPUMINFREQ}/${V_CPUMAXFREQ} MHz" || echo "CPU Max Frequency: ${V_CPUMAXFREQ} MHz"
 
 declare -a check_cpu_features=("avx2" "sse4_1")
 declare -a cpu_features=()
@@ -121,16 +101,11 @@ for feature in "${check_cpu_features[@]}"; do
     fi
 done
 
-if [ "${#cpu_features[@]}" -gt 0 ]; then
-    echo "CPU Features: " "${cpu_features[@]}"
-fi
+[ "${#cpu_features[@]}" -gt 0 ] && echo "CPU Features: " "${cpu_features[@]}"
 
 # TDP
 CPU_TDP=$(/usr/bin/system-settings-get system.cpu.tdp)
-if [ -n "$CPU_TDP" ]; then
-    MAX_TDP=$(ryzenadj -i | grep 'PPT LIMIT FAST' | awk '{printf "%.0f\n", $6}')
-    echo "Ryzen Mobile TDP: ${MAX_TDP}W"
-fi
+[ -n "$CPU_TDP" ] && echo "Ryzen Mobile TDP: $(ryzenadj -i | grep 'PPT LIMIT FAST' | awk '{printf "%.0f\n", $6}')W"
 
 # temperature in millidegree Celsius
 TEMPE=0
@@ -152,17 +127,14 @@ echo "Display Resolution: ${DISPLAYRES}"
 echo "Display Refresh Rate: ${DISPLAYRATE}"
 echo "Display Backend: ${DISPLAYBACKEND}"
 
-if [[ "${FULL_DISPLAY}" != 0 ]]; then
-	# OPENGL
-	if test "${V_BOARD}" = "x86" -o "${V_BOARD}" = "x86_64" -o "${V_BOARD}" = "x86_64_v3"; then
-	    V_OPENGLVERSION=$(DISPLAY=:0.0 glxinfo 2>/dev/null | sed -n -e 's|^OpenGL core profile version string:[ ]*\(.*\)|\1|p')
-	    if test -z "${V_OPENGLVERSION}"; then
-            V_OPENGLVERSION=$(DISPLAY=:0.0 glxinfo 2>/dev/null | sed -n -e 's|^OpenGL version string:[ ]*\(.*\)|\1|p')
-	    fi
-	    echo "OpenGL Driver Version: ${V_OPENGLVERSION}"
-	fi
-
-	# VULKAN
+if [ "${FULL_DISPLAY}" != 0 ]; then
+    # OPENGL
+    if [ "${V_BOARD}" = "x86" ] || [ "${V_BOARD}" = "x86_64" ] || [ "${V_BOARD}" = "x86_64_v3" ]; then
+        V_OPENGLVERSION=$(DISPLAY=:0.0 glxinfo 2>/dev/null | sed -n -e 's|^OpenGL core profile version string:[ ]*\(.*\)|\1|p')
+        [ -z "${V_OPENGLVERSION}" ] && V_OPENGLVERSION=$(DISPLAY=:0.0 glxinfo 2>/dev/null | sed -n -e 's|^OpenGL version string:[ ]*\(.*\)|\1|p')
+        echo "OpenGL Driver Version: ${V_OPENGLVERSION}"
+    fi
+    # VULKAN
     if [ "$(system-vulkan hasVulkan 2>/dev/null)" = "true" ]; then
         if [ "$(system-vulkan hasDiscrete 2>/dev/null)" = "true" ]; then
             echo "Vulkan Driver Name: $(system-vulkan discreteName | tr -d '\n')"
@@ -188,21 +160,17 @@ PREFSRC=$(ifconfig | sed -n -e 's|inet 127\.0\.0\.1||' -e 's|^[ ]*inet \([0-9\.\
 [ -n "$PREFSRC" ] && echo "Network IP Address: $PREFSRC"
 
 # Boot information
-if [[ "${FULL_DISPLAY}" != 0 ]]; then
-	if [ -d /sys/firmware/efi ]; then
-		echo "UEFI Boot: Yes"
-		if [ -x /usr/bin/mokutil ]; then
-			echo "Secure Boot: $(mokutil --sb-state 2>&1 | sed 's/^SecureBoot validation is//' | paste -sd ';')"
-		fi
-	else
-		echo "UEFI Boot: No"
-	fi
+if [ "${FULL_DISPLAY}" != 0 ]; then
+    if [ -d /sys/firmware/efi ]; then
+        echo "UEFI Boot: Yes"
+        [ -x /usr/bin/mokutil ] && echo "Secure Boot: $(mokutil --sb-state 2>&1 | sed 's/^SecureBoot validation is//' | paste -sd ';')"
+    else
+        echo "UEFI Boot: No"
+    fi
 fi
 
 # battery
-if test -n "${BATT}"; then
-    echo "Battery: ${BATT}%"
-fi
+[ -n "${BATT}" ] && echo "Battery: ${BATT}%"
 
 # battery health
 design_energy_file="/sys/class/power_supply/BAT0/energy_full_design"
@@ -219,18 +187,16 @@ if [ -e "$design_energy_file" ]; then
         printf \"%.0f\", health
     }")
 
-    if [ -n "$battery_health" ]; then
-        echo "Battery Health: $battery_health%"
-    fi
+    [ -n "$battery_health" ] && echo "Battery Health: $battery_health%"
 fi
 
 # PAD Battery
 for PADBAT in /sys/class/power_supply/*/device/uevent
 do
-    if test -e "${PADBAT}"; then
+    if [ -e "${PADBAT}" ]; then
         # HID devices only
         PADNAME=$(sed -nE 's/^HID_NAME=(.*)/\1/p' "${PADBAT}" 2>/dev/null)
-        if test -n "${PADNAME}"; then
+        if [ -n "${PADNAME}" ]; then
             # Remove PID if it exists in the name
             PADNAME=$(echo "${PADNAME}" | sed -E 's/ PID:[0-9]+//')
             # parent of parent / uevent


### PR DESCRIPTION
- It was just cosmetic, but now system-info shows model name without and extra '_' (caused by the file with the model name not ending with newline char).

- This "issue" did not affect sysconfigs because that is done by system-settings-get-master and it does not call system-info to get model name.

- Both scripts were optimized to avoid unnecessary pipes and a little execution time.