### PR TITLE
Add README for Allwinner A527/T527 boards

### DIFF
--- a/board/allwinner/t527/README.md
+++ b/board/allwinner/t527/README.md
@@ -1,0 +1,2 @@
+Allwinner A527/T527 boards 
+NOT WORKING AT THE MOMENT


### PR DESCRIPTION
Added a README file for Allwinner A527/T527 boards indicating current status.