### PR TITLE
Fix: Move user mapping to the end of docker run command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,9 @@ define DOCKER_RUN
 		-v $(DL_DIR):/build/buildroot/dl \
 		-v $(OUTPUT_DIR)/$*:/$* \
 		-v $(CCACHE_DIR)/$*:$(HOME)/.buildroot-ccache \
-		-u $(UID):$(GID) \
 		-v /etc/passwd:/etc/passwd:ro \
 		-v /etc/group:/etc/group:ro \
+		-u $(UID):$(GID) \
 		-e MPLCONFIGDIR=/tmp/matplotlib-config \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME)

--- a/Makefile.jenkins
+++ b/Makefile.jenkins
@@ -56,9 +56,9 @@ define DOCKER_RUN
 		-v $(DL_DIR):/build/buildroot/dl \
 		-v $(OUTPUT_DIR)/$*:/$* \
 		-v $(CCACHE_DIR):$(HOME)/.buildroot-ccache \
-		-u $(UID):$(GID) \
 		-v /etc/passwd:/etc/passwd:ro \
 		-v /etc/group:/etc/group:ro \
+		-u $(UID):$(GID) \
 		-e MPLCONFIGDIR=/tmp/matplotlib-config \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME)


### PR DESCRIPTION
Moving the `-u $(UID):$(GID)` option to the end of the `docker run`
command in both `Makefile` and `Makefile.jenkins` ensures that user and
group ID mapping is applied correctly for all mounted volumes. This
prevents potential permission issues within the Docker container.

Signed-off-by: Juliano Dorigão <jdorigao@gmail.com>
