### PR TITLE
Refactor Cemu generator and controller configuration

### DIFF
--- a/package/system/reglinux-configgen/configgen/configgen/generators/cemu/cemuConfig.py
+++ b/package/system/reglinux-configgen/configgen/configgen/generators/cemu/cemuConfig.py
@@ -233,14 +233,12 @@ def setCemuConfig(cemuConfig, system):
     proc = run(["/usr/bin/cemu/get-audio-device"], stdout=PIPE)
     cemuAudioDevice = proc.stdout.decode("utf-8")
     eslog.debug("*** audio device = {} ***".format(cemuAudioDevice))
-    if (
-        system.isOptSet("cemu_audio_config")
-        and system.getOptBoolean("cemu_audio_config")
+    if system.isOptSet("cemu_audio_config") and system.getOptBoolean(
+        "cemu_audio_config"
     ):
         setSectionConfig(cemuConfig, audio_root, "TVDevice", cemuAudioDevice)
-    elif (
-        system.isOptSet("cemu_audio_config")
-        and not system.getOptBoolean("cemu_audio_config")
+    elif system.isOptSet("cemu_audio_config") and not system.getOptBoolean(
+        "cemu_audio_config"
     ):
         # don't change the config setting
         eslog.debug("*** use config audio device ***")
@@ -249,7 +247,7 @@ def setCemuConfig(cemuConfig, system):
 
 
 # Show mouse for touchscreen actions
-def getMouseMode(self, config, rom):
+def getMouseMode(config, rom):
     if "cemu_touchpad" in config and config["cemu_touchpad"] == "1":
         return True
     else:

--- a/package/system/reglinux-configgen/configgen/configgen/generators/cemu/cemuControllers.py
+++ b/package/system/reglinux-configgen/configgen/configgen/generators/cemu/cemuControllers.py
@@ -1,5 +1,5 @@
 from os import path, mkdir, remove
-from xml.etree.cElementTree import SubElement, Element, ElementTree, indent
+from xml.etree.ElementTree import SubElement, Element, ElementTree, indent
 
 
 def setControllerConfig(system, playersControllers, profilesDir):
@@ -148,8 +148,7 @@ def setControllerConfig(system, playersControllers, profilesDir):
     # cemu assign pads by uuid then by index with the same uuid
     # so, if 2 pads have the same uuid, the index is not 0 but 1 for the 2nd one
     # sort pads by index
-    pads_by_index = playersControllers
-    dict(sorted(pads_by_index.items(), key=lambda kv: kv[1].index))
+    pads_by_index = dict(sorted(playersControllers.items(), key=lambda kv: kv[1].index))
     guid_n = {}
     guid_count = {}
     for playercontroller, pad in pads_by_index.items():
@@ -160,7 +159,7 @@ def setControllerConfig(system, playersControllers, profilesDir):
         guid_n[pad.index] = guid_count[pad.guid]
     ###
 
-    for playercontroller, pad in sorted(playersControllers.items()):
+    for playercontroller, pad in pads_by_index.items():
         root = Element("emulated_controller")
 
         # Set type from controller combination

--- a/package/system/reglinux-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/system/reglinux-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -3,10 +3,8 @@ from configgen.Command import Command
 import xml.parsers.expat
 from codecs import open
 from xml.dom import minidom
-import xml.etree.ElementTree as ET
 from os import path, mkdir, linesep
 from glob import iglob, escape
-from configgen.controllers import generate_sdl_controller_config
 from .cemuControllers import setControllerConfig
 from .cemuConfig import (
     CEMU_BIN_PATH,
@@ -75,9 +73,6 @@ class CemuGenerator(Generator):
         setCemuConfig(cemuConfig, system)
 
         # Save the config file
-        xml_file = open(CEMU_CONFIG_PATH, "w")
-
-        # TODO: python 3 - workaround to encode files in utf-8
         xml_file = open(CEMU_CONFIG_PATH, "w", "utf-8")
         dom_string = linesep.join(
             [s for s in cemuConfig.toprettyxml().splitlines() if s.strip()]
@@ -90,11 +85,4 @@ class CemuGenerator(Generator):
 
         command_array = [CEMU_BIN_PATH, "-f", "--force-no-menubar", "-g", rpxrom]
 
-        return Command(
-            array=command_array,
-            env={
-                "SDL_GAMECONTROLLERCONFIG": generate_sdl_controller_config(
-                    players_controllers
-                )
-            },
-        )
+        return Command(array=command_array)


### PR DESCRIPTION
- Use `xml.etree.ElementTree` instead of `xml.etree.cElementTree` for
  broader compatibility.
- Simplify conditional logic in `setCemuConfig`.
- Remove unused `self` parameter from `getMouseMode`.
- Remove unused `generate_sdl_controller_config` import and usage.
- Improve sorting logic for controller pads.
- Standardize file encoding to UTF-8.

Signed-off-by: Juliano Dorigão <jdorigao@gmail.com>
